### PR TITLE
Don't manage the ChocolateyInstall path

### DIFF
--- a/scripts/chocolatey.bat
+++ b/scripts/chocolatey.bat
@@ -4,4 +4,3 @@ powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object n
 <nul set /p ".=;C:\Chocolatey\bin" >> C:\Windows\Temp\PATH
 set /p PATH=<C:\Windows\Temp\PATH
 setx PATH "%PATH%" /m
-setx ChocolateyInstall "C:\Chocolatey" /m

--- a/scripts/chocopacks.bat
+++ b/scripts/chocopacks.bat
@@ -1,0 +1,6 @@
+:: Ensure C:\Chocolatey\bin is on the path
+set /p PATH=<C:\Windows\Temp\PATH
+
+:: Install all the things; for example:
+cmd /c choco install 7zip
+cmd /c choco install notepadplusplus


### PR DESCRIPTION
Either due to 7cdd777f8bc0661fbf8d58110562c910b07b8c53 or because of the radical changes in Chocolatey 0.9.21+ we no longer need to manually set the _ChocolateyInstall_ environment variable.

This includes a basic _chocopacks.bat_ so our friends don't have to waste hours figuring it out on their own.
