### PR TITLE
Amended answer file for Windows Server 2012 R2

### DIFF
--- a/answer_files/2012_r2/Autounattend.xml
+++ b/answer_files/2012_r2/Autounattend.xml
@@ -62,7 +62,8 @@
             </ImageInstall>
             <UserData>
                 <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
-                <ProductKey>D2N9P-3P6X9-2R39C-7RTCD-MDVJX
+                <ProductKey>
+                    <Key>D2N9P-3P6X9-2R39C-7RTCD-MDVJX</Key>
                     <WillShowUI>OnError</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>


### PR DESCRIPTION
The Windows Server 2012 R2 answer file's "ProductKey" element is missing a "Key" child element. Child element has been added as per http://technet.microsoft.com/en-us/library/cc721925(v=ws.10).aspx
