### PR TITLE
Don't define forwarded ports in the box

### DIFF
--- a/vagrantfile-windows_2008_r2.template
+++ b/vagrantfile-windows_2008_r2.template
@@ -13,10 +13,6 @@ Vagrant.configure("2") do |config|
     config.vm.guest = :windows  
     config.windows.halt_timeout = 15
 
-    # Port forward WinRM and RDP
-    config.vm.network :forwarded_port, guest: 3389, host: 3389
-    config.vm.network :forwarded_port, guest: 5985, host: 5985
-  
     # Berkshelf
     # config.berkshelf.enabled = true
   

--- a/vagrantfile-windows_2012.template
+++ b/vagrantfile-windows_2012.template
@@ -13,10 +13,6 @@ Vagrant.configure("2") do |config|
     config.vm.guest = :windows  
     config.windows.halt_timeout = 15
     
-    # Port forward WinRM and RDP
-    config.vm.network :forwarded_port, guest: 3389, host: 3389
-    config.vm.network :forwarded_port, guest: 5985, host: 5985
-    
     # Berkshelf
     # config.berkshelf.enabled = true
     

--- a/vagrantfile-windows_2012_r2.template
+++ b/vagrantfile-windows_2012_r2.template
@@ -13,10 +13,6 @@ Vagrant.configure("2") do |config|
     config.vm.guest = :windows  
     config.windows.halt_timeout = 15
     
-    # Port forward WinRM and RDP
-    config.vm.network :forwarded_port, guest: 3389, host: 3389
-    config.vm.network :forwarded_port, guest: 5985, host: 5985
-    
     # Berkshelf
     # config.berkshelf.enabled = true
     

--- a/vagrantfile-windows_7.template
+++ b/vagrantfile-windows_7.template
@@ -13,10 +13,6 @@ Vagrant.configure("2") do |config|
     config.vm.guest = :windows  
     config.windows.halt_timeout = 15
     
-    # Port forward WinRM and RDP
-    config.vm.network :forwarded_port, guest: 3389, host: 3389
-    config.vm.network :forwarded_port, guest: 5985, host: 5985
-    
     # Berkshelf
     # config.berkshelf.enabled = true
     


### PR DESCRIPTION
Due to the Vagrantfile merging algorithm, having default port forwarding in the box breaks multi-VM port forwarding setups.

http://docs.vagrantup.com/v2/vagrantfile/index.html

See WinRb/vagrant-windows#171 for more info.

My host also has WinRM activated, so this standard port forwarding setup always halts vagrant up.
