### PR TITLE
Puppet 3.3.1+ installer extends path.

### DIFF
--- a/scripts/puppet.bat
+++ b/scripts/puppet.bat
@@ -1,10 +1,6 @@
 if not exist "C:\Windows\Temp\puppet.msi" (
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://downloads.puppetlabs.com/windows/puppet-3.3.0.msi', 'C:\Windows\Temp\puppet.msi')" <NUL
+  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://downloads.puppetlabs.com/windows/puppet-3.3.1.msi', 'C:\Windows\Temp\puppet.msi')" <NUL
 )
 
 :: http://docs.puppetlabs.com/pe/latest/install_windows.html
 msiexec /qn /i C:\Windows\Temp\puppet.msi /log C:\Windows\Temp\puppet.log
-
-<nul set /p ".=;C:\Program Files (x86)\Puppet Labs\Puppet\bin" >> C:\Windows\Temp\PATH
-set /p PATH=<C:\Windows\Temp\PATH
-setx PATH "%PATH%" /m


### PR DESCRIPTION
Since Puppet 3.3.1, the MSI installer adds puppet to the PATH

http://projects.puppetlabs.com/issues/22700

The Puppet installation script can be simplified by using this minor version bump.
