### PR TITLE
Fixed ProductKey element in server 2012 R2 answer files

### DIFF
--- a/answer_files/2012_r2/Autounattend.xml
+++ b/answer_files/2012_r2/Autounattend.xml
@@ -63,7 +63,7 @@
             <UserData>
                 <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
                 <ProductKey>
-					<Key>D2N9P-3P6X9-2R39C-7RTCD-MDVJX</Key>
+                    <Key>D2N9P-3P6X9-2R39C-7RTCD-MDVJX</Key>
                     <WillShowUI>OnError</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>

--- a/answer_files/2012_r2_core/Autounattend.xml
+++ b/answer_files/2012_r2_core/Autounattend.xml
@@ -63,7 +63,7 @@
             <UserData>
                 <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
                 <ProductKey>
-					<Key>D2N9P-3P6X9-2R39C-7RTCD-MDVJX</Key>
+                    <Key>D2N9P-3P6X9-2R39C-7RTCD-MDVJX</Key>
                     <WillShowUI>OnError</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>


### PR DESCRIPTION
I was getting an "unable to read product key" error from windows using the Server 2012 R2 templates until I adjusted the ProductKey element in the answer files to put the key in its own "Key" element, based on other sample answer files I found.  It works fine with these changes.
