### PR TITLE
Unattended setup files have incorrect key element

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following Windows versions are known to work (built with VMware Fusion 6.0.2
 
 ### Windows Editions
 
-All Windows Server versions are defaulted to the Server Standard edition. You can modify this by editing the Autounattend.xml file, changing the `ImageInstall`>`OSImage`>`InstallFrom`>`MetaData`>`Value` element (e.g. to Windows Server 2012 R2 SERVERDATACENTER). You also need to update the `UserData`>`ProductKey` element with the appropriate key from http://technet.microsoft.com/en-us/library/jj612867.aspx.
+All Windows Server versions are defaulted to the Server Standard edition. You can modify this by editing the Autounattend.xml file, changing the `ImageInstall`>`OSImage`>`InstallFrom`>`MetaData`>`Value` element (e.g. to Windows Server 2012 R2 SERVERDATACENTER). You also need to update the `UserData`>`ProductKey` element with the appropriate key from http://technet.microsoft.com/en-us/library/jj612867.aspx.  Note that you will need to enclose the ProductKey in a child `Key` element, which differs from the default trial edition format provided in these templates.  See [this TechNet article](http://technet.microsoft.com/en-us/library/cc721925(v=ws.10).aspx) for more details.
 
 ### Windows Updates
 

--- a/answer_files/2008_r2/Autounattend.xml
+++ b/answer_files/2008_r2/Autounattend.xml
@@ -33,6 +33,7 @@
                 <Organization>Vagrant Inc.</Organization>
                 <!-- Product Key from http://technet.microsoft.com/en-us/library/ff793406.aspx -->
                 <ProductKey>
+                    <!--<Key>Product Key</Key>-->
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
             </UserData>

--- a/answer_files/2008_r2_core/Autounattend.xml
+++ b/answer_files/2008_r2_core/Autounattend.xml
@@ -33,6 +33,7 @@
                 <Organization>Vagrant Inc.</Organization>
                 <!-- Product Key from http://technet.microsoft.com/en-us/library/ff793406.aspx -->
                 <ProductKey>
+                    <!--<Key>Product Key</Key>-->
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
             </UserData>

--- a/answer_files/2012/Autounattend.xml
+++ b/answer_files/2012/Autounattend.xml
@@ -32,8 +32,8 @@
                 <FullName>Vagrant Administrator</FullName>
                 <Organization>Vagrant Inc.</Organization>
                 <!-- Product Key from http://technet.microsoft.com/en-us/library/ff793406.aspx -->
-                <ProductKey>
-                    <Key>XC9B7-NBPP2-83J2H-RHMBY-92BT4</Key>
+                <ProductKey>XC9B7-NBPP2-83J2H-RHMBY-92BT4
+                    <!--<Key>Product Key</Key>-->
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
             </UserData>

--- a/answer_files/2012_r2/Autounattend.xml
+++ b/answer_files/2012_r2/Autounattend.xml
@@ -63,6 +63,7 @@
             <UserData>
                 <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
                 <ProductKey>D2N9P-3P6X9-2R39C-7RTCD-MDVJX
+                    <!--<Key>Product Key</Key>-->
                     <WillShowUI>OnError</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>

--- a/answer_files/2012_r2_core/Autounattend.xml
+++ b/answer_files/2012_r2_core/Autounattend.xml
@@ -62,8 +62,8 @@
             </ImageInstall>
             <UserData>
                 <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
-                <ProductKey>
-                    <Key>D2N9P-3P6X9-2R39C-7RTCD-MDVJX</Key>
+                <ProductKey>D2N9P-3P6X9-2R39C-7RTCD-MDVJX
+                    <!--<Key>Product Key</Key>-->
                     <WillShowUI>OnError</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>

--- a/answer_files/7/Autounattend.xml
+++ b/answer_files/7/Autounattend.xml
@@ -32,8 +32,8 @@
                 <FullName>Vagrant Administrator</FullName>
                 <Organization>Vagrant Inc.</Organization>
                 <!-- Product Key from http://technet.microsoft.com/en-us/library/ff793406.aspx -->
-                <ProductKey>
-                    <Key>XC9B7-NBPP2-83J2H-RHMBY-92BT4</Key>
+                <ProductKey>XC9B7-NBPP2-83J2H-RHMBY-92BT4
+                    <!--<Key>Product Key</Key>-->
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
             </UserData>


### PR DESCRIPTION
Not a drastically important one, but the product keys need to be declared in a `<Key />` element, as per http://technet.microsoft.com/en-us/library/cc721925(v=ws.10).aspx.  I was getting blocked during setup without.

Hope that helps!
