### PR TITLE
fix autostart winrm service, blank after equal sign required

### DIFF
--- a/answer_files/2008_r2/Autounattend.xml
+++ b/answer_files/2008_r2/Autounattend.xml
@@ -185,7 +185,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c sc config winrm start=auto</CommandLine>
+                    <CommandLine>cmd.exe /c sc config winrm start= auto</CommandLine>
                     <Description>Win RM Autostart</Description>
                     <Order>14</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2008_r2_core/Autounattend.xml
+++ b/answer_files/2008_r2_core/Autounattend.xml
@@ -221,7 +221,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c sc config winrm start=auto</CommandLine>
+                    <CommandLine>cmd.exe /c sc config winrm start= auto</CommandLine>
                     <Description>Win RM Autostart</Description>
                     <Order>20</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2012/Autounattend.xml
+++ b/answer_files/2012/Autounattend.xml
@@ -190,7 +190,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c sc config winrm start=auto</CommandLine>
+                    <CommandLine>cmd.exe /c sc config winrm start= auto</CommandLine>
                     <Description>Win RM Autostart</Description>
                     <Order>14</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2012_r2/Autounattend.xml
+++ b/answer_files/2012_r2/Autounattend.xml
@@ -187,7 +187,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c sc config winrm start=auto</CommandLine>
+                    <CommandLine>cmd.exe /c sc config winrm start= auto</CommandLine>
                     <Description>Win RM Autostart</Description>
                     <Order>14</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2012_r2_core/Autounattend.xml
+++ b/answer_files/2012_r2_core/Autounattend.xml
@@ -187,7 +187,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c sc config winrm start=auto</CommandLine>
+                    <CommandLine>cmd.exe /c sc config winrm start= auto</CommandLine>
                     <Description>Win RM Autostart</Description>
                     <Order>14</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/7/Autounattend.xml
+++ b/answer_files/7/Autounattend.xml
@@ -186,7 +186,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c sc config winrm start=auto</CommandLine>
+                    <CommandLine>cmd.exe /c sc config winrm start= auto</CommandLine>
                     <Description>Win RM Autostart</Description>
                     <Order>14</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/81/Autounattend.xml
+++ b/answer_files/81/Autounattend.xml
@@ -183,7 +183,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c sc config winrm start=auto</CommandLine>
+                    <CommandLine>cmd.exe /c sc config winrm start= auto</CommandLine>
                     <Description>Win RM Autostart</Description>
                     <Order>14</Order>
                     <RequiresUserInput>true</RequiresUserInput>


### PR DESCRIPTION
The WinRM autostart command had a typo, so the service still starts after booting the guest, but it will be started delayed (after 120 seconds). So using such boxes with vagrant results in a slow login with vagrant-windows plugin.
I have compared both the winrm script in [basebox-packer](https://github.com/misheska/basebox-packer) repo
where the typo is already fixed 2 months ago.

In the command 

```
cmd.exe /c sc config winrm start= auto
```

there must be a space after the equal sign.
