### PR TITLE
fix passing exit status from shell provision to packer

### DIFF
--- a/scripts/openssh.ps1
+++ b/scripts/openssh.ps1
@@ -32,6 +32,11 @@ Write-Host "Setting SSH home directories"
     Foreach-Object { $_ -replace '/home/(\w+)', '/cygdrive/c/Users/$1' } |
     Set-Content 'C:\Program Files\OpenSSH\etc\passwd'
 
+# Set shell to /bin/sh to return exit status
+$passwd_file = Get-Content 'C:\Program Files\OpenSSH\etc\passwd'
+$passwd_file = $passwd_file -replace '/bin/bash', '/bin/sh'
+Set-Content 'C:\Program Files\OpenSSH\etc\passwd' $passwd_file
+
 # fix opensshd to not be strict
 Write-Host "Setting OpenSSH to be non-strict"
 $sshd_config = Get-Content "C:\Program Files\OpenSSH\etc\sshd_config"


### PR DESCRIPTION
when a shell provision returns with an exit code > 0 packer should fail the build.
from some reason /bin/bash shell of OpenSSH always return exit code 0 which could hide the fact that the provision failed..

this commit will configure the passwd to use the /bin/sh shell which returns the exit code as expected

Note: I didn't test this with vagrant 
