### PR TITLE
update opensshd to 6.6.p1

### DIFF
--- a/scripts/openssh.ps1
+++ b/scripts/openssh.ps1
@@ -6,10 +6,10 @@ Write-Host "AutoStart: $AutoStart"
 $is_64bit = [IntPtr]::size -eq 8
 
 # setup openssh
-$ssh_download_url = "http://www.mls-software.com/files/setupssh-6.4p1-1.exe"
+$ssh_download_url = "http://www.mls-software.com/files/setupssh-6.6p1-1.exe"
 if ($is_64bit) {
     Write-Host "64 bit OS found"
-    $ssh_download_url = "http://www.mls-software.com/files/setupssh-6.4p1-1(x64).exe"
+    $ssh_download_url = "http://www.mls-software.com/files/setupssh-6.6p1-1(x64).exe"
 }
 
 if (!(Test-Path "C:\Program Files\OpenSSH\bin\ssh.exe")) {


### PR DESCRIPTION
This is an update to OpenSSL 1.0.1g-1 to address the Heartbleed vulnerability. The binaries for OpenSSH have stayed the same.
