### PR TITLE
Fixed vm-ware iso url

### DIFF
--- a/windows_2008_r2_core.json
+++ b/windows_2008_r2_core.json
@@ -1,7 +1,7 @@
 {
   "builders": [{
     "type": "vmware-iso",
-    "iso_url": "http://care.dlservice.microsoft.com/dl/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
+    "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
     "iso_checksum_type": "md5",
     "iso_checksum": "4263be2cf3c59177c45085c0a7bc6ca5",
     "headless": true,


### PR DESCRIPTION
The vm-ware iso was still pointing to the old location
