### PR TITLE
Updated for Vagrant 1.6.0

### DIFF
--- a/vagrantfile-windows_2008_r2.template
+++ b/vagrantfile-windows_2008_r2.template
@@ -16,7 +16,6 @@ Vagrant.configure("2") do |config|
     config.windows.halt_timeout = 15
 
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
-    config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
 
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true

--- a/vagrantfile-windows_2012.template
+++ b/vagrantfile-windows_2012.template
@@ -16,7 +16,6 @@ Vagrant.configure("2") do |config|
     config.windows.halt_timeout = 15
 
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
-    config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
 
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true

--- a/vagrantfile-windows_2012_r2.template
+++ b/vagrantfile-windows_2012_r2.template
@@ -16,7 +16,6 @@ Vagrant.configure("2") do |config|
     config.windows.halt_timeout = 15
 
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
-    config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
 
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true

--- a/vagrantfile-windows_7.template
+++ b/vagrantfile-windows_7.template
@@ -16,7 +16,6 @@ Vagrant.configure("2") do |config|
     config.windows.halt_timeout = 15
 
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
-    config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
 
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true

--- a/vagrantfile-windows_81.template
+++ b/vagrantfile-windows_81.template
@@ -16,7 +16,6 @@ Vagrant.configure("2") do |config|
     config.windows.halt_timeout = 15
 
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
-    config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
 
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true


### PR DESCRIPTION
Removed the requirement for the vagrant-windows plugin
added the port forwarding for rdp
disabling the GUI Message for virtualbox
gave vmmare 2 cpu’s to match virtualbox
