### PR TITLE
update location of the default vagrant key

### DIFF
--- a/scripts/vagrant-ssh.bat
+++ b/scripts/vagrant-ssh.bat
@@ -2,5 +2,5 @@
 if exist a:\vagrant.pub (
   copy a:\vagrant.pub C:\Users\vagrant\.ssh\authorized_keys
 ) else (
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub', 'C:\Users\vagrant\.ssh\authorized_keys')" <NUL
+  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub', 'C:\Users\vagrant\.ssh\authorized_keys')" <NUL
 )


### PR DESCRIPTION
The github raw domain has changed, and I got an error trying to provision with the old one - update to the correct location.
