### PR TITLE
Forward ssh port

### DIFF
--- a/vagrantfile-windows_2008_r2.template
+++ b/vagrantfile-windows_2008_r2.template
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |config|
     config.windows.halt_timeout = 15
 
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
-
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
 
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true

--- a/vagrantfile-windows_2012.template
+++ b/vagrantfile-windows_2012.template
@@ -16,6 +16,7 @@ Vagrant.configure("2") do |config|
     config.windows.halt_timeout = 15
 
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
 
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true

--- a/vagrantfile-windows_2012_r2.template
+++ b/vagrantfile-windows_2012_r2.template
@@ -16,6 +16,7 @@ Vagrant.configure("2") do |config|
     config.windows.halt_timeout = 15
 
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
 
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true

--- a/vagrantfile-windows_7.template
+++ b/vagrantfile-windows_7.template
@@ -16,6 +16,7 @@ Vagrant.configure("2") do |config|
     config.windows.halt_timeout = 15
 
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
 
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true

--- a/vagrantfile-windows_81.template
+++ b/vagrantfile-windows_81.template
@@ -16,6 +16,7 @@ Vagrant.configure("2") do |config|
     config.windows.halt_timeout = 15
 
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
 
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true


### PR DESCRIPTION
`vagrant ssh` doesn't work when the box first starts up because the port is not forwarded by default on Windows. It can be added to the Vagrantfile, but it is helpful to have that in the template.

Also updated the documentation related to the Vagrantfile template in `README.md`
