### PR TITLE
Update chocolatey scripts with 0.9.8.27's default install location.

### DIFF
--- a/scripts/chocolatey.bat
+++ b/scripts/chocolatey.bat
@@ -1,5 +1,5 @@
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" <NUL
 
-<nul set /p ".=;C:\Chocolatey\bin" >> C:\Windows\Temp\PATH
+<nul set /p ".=;%ALLUSERSPROFILE%\chocolatey\bin" >> C:\Windows\Temp\PATH
 set /p PATH=<C:\Windows\Temp\PATH
 setx PATH "%PATH%" /m


### PR DESCRIPTION
Chocolatey's default install location has changed from `C:\Chocolatey` to `%ALLUSERSPROFILE%\chocolatey`
