### PR TITLE
enable RDP after installation

### DIFF
--- a/scripts/enable-rdp.bat
+++ b/scripts/enable-rdp.bat
@@ -1,0 +1,2 @@
+netsh advfirewall firewall add rule name="Open Port 3389" dir=in action=allow protocol=TCP localport=3389
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server" /v fDenyTSConnections /t REG_DWORD /d 0 /f

--- a/windows_2008_r2.json
+++ b/windows_2008_r2.json
@@ -75,6 +75,7 @@
         "./scripts/vm-guest-tools.bat",
         "./scripts/chef.bat",
         "./scripts/vagrant-ssh.bat",
+        "./scripts/enable-rdp.bat",
         "./scripts/compact.bat"
       ]
     },

--- a/windows_2008_r2_core.json
+++ b/windows_2008_r2_core.json
@@ -75,6 +75,7 @@
         "./scripts/vm-guest-tools.bat",
         "./scripts/chef.bat",
         "./scripts/vagrant-ssh.bat",
+        "./scripts/enable-rdp.bat",
         "./scripts/compact.bat"
       ]
     },

--- a/windows_2012.json
+++ b/windows_2012.json
@@ -74,7 +74,8 @@
       "scripts": [
         "./scripts/vm-guest-tools.bat",
         "./scripts/chef.bat",
-        "./scripts/vagrant-ssh.bat"
+        "./scripts/vagrant-ssh.bat",
+        "./scripts/enable-rdp.bat"
       ]
     },
     {

--- a/windows_2012_r2.json
+++ b/windows_2012_r2.json
@@ -75,6 +75,7 @@
         "./scripts/vm-guest-tools.bat",
         "./scripts/chef.bat",
         "./scripts/vagrant-ssh.bat",
+        "./scripts/enable-rdp.bat",
         "./scripts/compile-dotnet-assemblies.bat",
         "./scripts/compact.bat"
       ]

--- a/windows_2012_r2_core.json
+++ b/windows_2012_r2_core.json
@@ -75,6 +75,7 @@
         "./scripts/vm-guest-tools.bat",
         "./scripts/chef.bat",
         "./scripts/vagrant-ssh.bat",
+        "./scripts/enable-rdp.bat",
         "./scripts/compile-dotnet-assemblies.bat",
         "./scripts/compact.bat"
       ]

--- a/windows_7.json
+++ b/windows_7.json
@@ -74,7 +74,8 @@
       "scripts": [
         "./scripts/vm-guest-tools.bat",
         "./scripts/chef.bat",
-        "./scripts/vagrant-ssh.bat"
+        "./scripts/vagrant-ssh.bat",
+        "./scripts/enable-rdp.bat"
       ]
     },
     {

--- a/windows_81.json
+++ b/windows_81.json
@@ -74,7 +74,8 @@
       "scripts": [
         "./scripts/vm-guest-tools.bat",
         "./scripts/chef.bat",
-        "./scripts/vagrant-ssh.bat"
+        "./scripts/vagrant-ssh.bat",
+        "./scripts/enable-rdp.bat"
       ]
     },
     {


### PR DESCRIPTION
Need to open the right port in the firewall, and to turn on remote desktop
(terminal services) in the registry
