### PR TITLE
Fixes issue where SSH connects before Windows Updates installs and does ...

### DIFF
--- a/answer_files/2008_r2/Autounattend.xml
+++ b/answer_files/2008_r2/Autounattend.xml
@@ -248,12 +248,6 @@
                     <Description>Enable Microsoft Updates</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\openssh.ps1</CommandLine>
-                    <Description>Install OpenSSH</Description>
-                    <Order>99</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1</CommandLine>
                     <Description>Install Windows Updates</Description>
                     <Order>100</Order>

--- a/answer_files/2008_r2_core/Autounattend.xml
+++ b/answer_files/2008_r2_core/Autounattend.xml
@@ -284,12 +284,6 @@
                     <Description>Enable Microsoft Updates</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\openssh.ps1</CommandLine>
-                    <Description>Install OpenSSH</Description>
-                    <Order>99</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1</CommandLine>
                     <Description>Install Windows Updates</Description>
                     <Order>100</Order>

--- a/answer_files/2012/Autounattend.xml
+++ b/answer_files/2012/Autounattend.xml
@@ -253,12 +253,6 @@
                     <Description>Enable Microsoft Updates</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\openssh.ps1</CommandLine>
-                    <Description>Install OpenSSH</Description>
-                    <Order>99</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1</CommandLine>
                     <Description>Install Windows Updates</Description>
                     <Order>100</Order>

--- a/answer_files/2012_r2/Autounattend.xml
+++ b/answer_files/2012_r2/Autounattend.xml
@@ -250,12 +250,6 @@
                     <Description>Enable Microsoft Updates</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\openssh.ps1</CommandLine>
-                    <Description>Install OpenSSH</Description>
-                    <Order>99</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1</CommandLine>
                     <Description>Install Windows Updates</Description>
                     <Order>100</Order>

--- a/answer_files/2012_r2_core/Autounattend.xml
+++ b/answer_files/2012_r2_core/Autounattend.xml
@@ -250,12 +250,6 @@
                     <Description>Enable Microsoft Updates</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\openssh.ps1</CommandLine>
-                    <Description>Install OpenSSH</Description>
-                    <Order>99</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1</CommandLine>
                     <Description>Install Windows Updates</Description>
                     <Order>100</Order>

--- a/answer_files/7/Autounattend.xml
+++ b/answer_files/7/Autounattend.xml
@@ -249,12 +249,6 @@
                     <Description>Enable Microsoft Updates</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\openssh.ps1</CommandLine>
-                    <Description>Install OpenSSH</Description>
-                    <Order>99</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1</CommandLine>
                     <Description>Install Windows Updates</Description>
                     <Order>100</Order>

--- a/answer_files/81/Autounattend.xml
+++ b/answer_files/81/Autounattend.xml
@@ -246,12 +246,6 @@
                     <Description>Enable Microsoft Updates</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\openssh.ps1</CommandLine>
-                    <Description>Install OpenSSH</Description>
-                    <Order>99</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1</CommandLine>
                     <Description>Install Windows Updates</Description>
                     <Order>100</Order>

--- a/scripts/win-updates.ps1
+++ b/scripts/win-updates.ps1
@@ -17,14 +17,12 @@ function Check-ContinueRestartOrEnd() {
             Check-WindowsUpdates
             
             if (($global:MoreUpdates -eq 1) -and ($script:Cycles -le $global:MaxCycles)) {
-                Stop-Service $script:ServiceName -Force
-                Set-Service -Name $script:ServiceName -StartupType Disabled -Status Stopped 
                 Install-WindowsUpdates
             } elseif ($script:Cycles -gt $global:MaxCycles) {
                 Write-Host "Exceeded Cycle Count - Stopping"
 			} else {
                 Write-Host "Done Installing Windows Updates"
-                Set-Service -Name $script:ServiceName -StartupType Automatic -Status Running         
+                Invoke-Expression "a:\openssh.ps1 -AutoStart"
             }
         }
         1 {
@@ -99,7 +97,7 @@ function Install-WindowsUpdates() {
         Write-Host 'No updates available to install...'
         $global:MoreUpdates=0
         $global:RestartRequired=0
-        Set-Service -Name $script:ServiceName -StartupType Automatic -Status Running
+        Invoke-Expression "a:\openssh.ps1 -AutoStart"
         break
     }
 
@@ -163,11 +161,6 @@ $script:UpdateSession.ClientApplicationID = 'Packer Windows Update Installer'
 $script:UpdateSearcher = $script:UpdateSession.CreateUpdateSearcher()
 $script:SearchResult = New-Object -ComObject 'Microsoft.Update.UpdateColl'
 $script:Cycles = 0
-
-$script:ServiceName = "OpenSSHd"
-
-Stop-Service $script:ServiceName -Force
-Set-Service -Name $script:ServiceName -StartupType Disabled -Status Stopped 
 
 Check-WindowsUpdates
 if ($global:MoreUpdates -eq 1) {


### PR DESCRIPTION
...not allow Updates to finish. joefitzgerald/packer-windows#59

My solution is pretty straightforward -- Don't install SSH until Updates have completed (in the win-updates.ps1 file) or no updates remain. Continue to install SSH if Windows updates are not applied (via autounattend.xml)
