### PR TITLE
Removes chef from default install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Forward SSH port by default on Vagrant boxes (#76)
 * Box no longer auto logs on upon boot (#66)
 * Updated Virtualbox Guest OS Type for Win8.1 (#81)
+* Chef is no longer installed by default
 
 ## v1.21 (Aug 6th, 2014)
 

--- a/windows_2012_r2.json
+++ b/windows_2012_r2.json
@@ -73,7 +73,6 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
         "./scripts/vm-guest-tools.bat",
-        "./scripts/chef.bat",
         "./scripts/vagrant-ssh.bat",
         "./scripts/enable-rdp.bat",
         "./scripts/compile-dotnet-assemblies.bat",

--- a/windows_2012_r2_core.json
+++ b/windows_2012_r2_core.json
@@ -73,7 +73,6 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
         "./scripts/vm-guest-tools.bat",
-        "./scripts/chef.bat",
         "./scripts/vagrant-ssh.bat",
         "./scripts/enable-rdp.bat",
         "./scripts/compile-dotnet-assemblies.bat",

--- a/windows_7.json
+++ b/windows_7.json
@@ -73,7 +73,6 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
         "./scripts/vm-guest-tools.bat",
-        "./scripts/chef.bat",
         "./scripts/vagrant-ssh.bat",
         "./scripts/disable-auto-logon.bat",
         "./scripts/enable-rdp.bat"

--- a/windows_81.json
+++ b/windows_81.json
@@ -73,7 +73,6 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
         "./scripts/vm-guest-tools.bat",
-        "./scripts/chef.bat",
         "./scripts/vagrant-ssh.bat",
         "./scripts/disable-auto-logon.bat",
         "./scripts/enable-rdp.bat"


### PR DESCRIPTION
It seemed odd to me that chef is included as a default provisioning tool in this project when there are optional scripts for others. Rather than taking a stance on what should be installed by default, it seems like we should simply let everyone choose what's right for them as a manual provisioning step to install their provisioner of choice.

So with that in mind, I propose we remove Chef as a default installed tool