### PR TITLE
Document problems with Chef provisioner in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,17 @@ Doing so will give you hours back in your day, which is a good thing.
 
 ### OpenSSH / WinRM
 
-Currently, [Packer](http://packer.io) has a single communitator that uses SSH. This means we need an SSH server installed on Windows - which is not optimal as we could use WinRM to communicate with the Windows VM. In the short term, everything works well with SSH; in the medium term, work is underway on a WinRM communicator for Packer.
+Currently, [Packer](http://packer.io) has a single communitator that uses SSH. This means we need an SSH server installed on Windows - which is not optimal as we could use WinRM to communicate with the Windows VM. In the short term, many Packer features works well with SSH; in the medium term, work is underway on a WinRM communicator for Packer.
 
 If you have serious objections to OpenSSH being installed, you can always add another stage to your build pipeline:
 
 * Build a base box using Packer
 * Create a Vagrantfile, use the base box from Packer, connect to the VM via WinRM (using the [vagrant-windows](https://github.com/WinRb/vagrant-windows) plugin) and disable the 'sshd' service or uninstall OpenSSH completely
 * Perform a Vagrant run and output a .box file
+
+It's worth mentioning that many Chef cookbooks will not work properly through Cygwin's SSH environment on Windows. Specifically, packages that need access to environment-specific configurations such as the `PATH` variable, will fail. This includes packages that use the Windows installer, `msiexec.exe`.
+
+It's currently recommended that you add a second step to your pipeline and use Vagrant to install your packages through Chef.
 
 ### Using .box Files With Vagrant
 


### PR DESCRIPTION
As Packer currently has no support for WinRM and all communication
with the VM is done over SSH in Cygwin, some Packer features fail to
work properly including Chef. While Chef works for many packages, it
doesn't work with those that make assumptions about available programs
in PATH such as msiexec.exe.

This patch addresses the issue by documenting the problem in README.md
with hopes that future developers will spend less time trying to solve
Chef-related issues.

This addresses the issue raised here: https://github.com/joefitzgerald/packer-windows/issues/101
