### PR TITLE
Update OpenSSH to version 6.7p1-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Clarified use of the `<Key>` element in Windows 8.1 autounattend file (#114)
+* Fixed issue with OpenSSH / Packer race condition (#113)
+* 
+
 ## v1.23 (Nov 5th, 2014)
 
 * Resolved issue with Windows 7 not successfully completing an update run (#83)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Clarified use of the `<Key>` element in Windows 8.1 autounattend file (#114)
 * Fixed issue with OpenSSH / Packer race condition (#113)
-* 
+* Fixed issue with Windows 8.1 product key and computer name (#121)
+* Fixed issue where disk size would always be 60GB regardless of value in packer template (#117)
 
 ## v1.23 (Nov 5th, 2014)
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Doing so will give you hours back in your day, which is a good thing.
 
 ### OpenSSH / WinRM
 
-Currently, [Packer](http://packer.io) has a single communitator that uses SSH. This means we need an SSH server installed on Windows - which is not optimal as we could use WinRM to communicate with the Windows VM. In the short term, many Packer features works well with SSH; in the medium term, work is underway on a WinRM communicator for Packer.
+Currently, [Packer](http://packer.io) has a single communitator that uses SSH. This means we need an SSH server installed on Windows - which is not optimal as we could use WinRM to communicate with the Windows VM. In the short term, many Packer features work well with SSH; in the medium term, work is underway on a WinRM communicator for Packer.
 
 If you have serious objections to OpenSSH being installed, you can always add another stage to your build pipeline:
 

--- a/README.md
+++ b/README.md
@@ -82,13 +82,17 @@ Doing so will give you hours back in your day, which is a good thing.
 
 ### OpenSSH / WinRM
 
-Currently, [Packer](http://packer.io) has a single communitator that uses SSH. This means we need an SSH server installed on Windows - which is not optimal as we could use WinRM to communicate with the Windows VM. In the short term, everything works well with SSH; in the medium term, work is underway on a WinRM communicator for Packer.
+Currently, [Packer](http://packer.io) has a single communitator that uses SSH. This means we need an SSH server installed on Windows - which is not optimal as we could use WinRM to communicate with the Windows VM. In the short term, many Packer features works well with SSH; in the medium term, work is underway on a WinRM communicator for Packer.
 
 If you have serious objections to OpenSSH being installed, you can always add another stage to your build pipeline:
 
 * Build a base box using Packer
 * Create a Vagrantfile, use the base box from Packer, connect to the VM via WinRM (using the [vagrant-windows](https://github.com/WinRb/vagrant-windows) plugin) and disable the 'sshd' service or uninstall OpenSSH completely
 * Perform a Vagrant run and output a .box file
+
+It's worth mentioning that many Chef cookbooks will not work properly through Cygwin's SSH environment on Windows. Specifically, packages that need access to environment-specific configurations such as the `PATH` variable, will fail. This includes packages that use the Windows installer, `msiexec.exe`.
+
+It's currently recommended that you add a second step to your pipeline and use Vagrant to install your packages through Chef.
 
 ### Using .box Files With Vagrant
 

--- a/scripts/openssh.ps1
+++ b/scripts/openssh.ps1
@@ -6,7 +6,7 @@ Write-Output "AutoStart: $AutoStart"
 $is_64bit = [IntPtr]::size -eq 8
 
 # setup openssh
-$ssh_download_url = "http://www.mls-software.com/files/setupssh-6.7p1-1.exe"
+$ssh_download_url = "http://www.mls-software.com/files/setupssh-6.7p1-2.exe"
 
 if (!(Test-Path "C:\Program Files\OpenSSH\bin\ssh.exe")) {
     Write-Output "Downloading $ssh_download_url"

--- a/scripts/openssh.ps1
+++ b/scripts/openssh.ps1
@@ -50,7 +50,7 @@ $sshd_config = $sshd_config -replace 'Banner /etc/banner.txt', '#Banner /etc/ban
 $sshd_config = $sshd_config -replace 'Port 2222', "Port 22"
 Set-Content "C:\Program Files\OpenSSH\etc\sshd_config" $sshd_config
 
-Write-Host "Removing ed25519 key as Vagrant net-ssh 2.9.1 does not support it"
+Write-Output "Removing ed25519 key as Vagrant net-ssh 2.9.1 does not support it"
 Remove-Item -Force -ErrorAction SilentlyContinue "C:\Program Files\OpenSSH\etc\ssh_host_ed25519_key"
 Remove-Item -Force -ErrorAction SilentlyContinue "C:\Program Files\OpenSSH\etc\ssh_host_ed25519_key.pub"
 

--- a/scripts/openssh.ps1
+++ b/scripts/openssh.ps1
@@ -50,6 +50,10 @@ $sshd_config = $sshd_config -replace 'Banner /etc/banner.txt', '#Banner /etc/ban
 $sshd_config = $sshd_config -replace 'Port 2222', "Port 22"
 Set-Content "C:\Program Files\OpenSSH\etc\sshd_config" $sshd_config
 
+Write-Host "Removing ed25519 key as Vagrant net-ssh 2.9.1 does not support it"
+Remove-Item -Force -ErrorAction SilentlyContinue "C:\Program Files\OpenSSH\etc\ssh_host_ed25519_key"
+Remove-Item -Force -ErrorAction SilentlyContinue "C:\Program Files\OpenSSH\etc\ssh_host_ed25519_key.pub"
+
 # use c:\Windows\Temp as /tmp location
 Write-Output "Setting temp directory location"
 Remove-Item -Recurse -Force -ErrorAction SilentlyContinue "C:\Program Files\OpenSSH\tmp"


### PR DESCRIPTION
I've just seen [here](http://www.mls-software.com/opensshd.html) that there is a newer version of OpenSSH. In Version 6.6.1p1-3 the 32bit and 64bit versions are inside one installer, so there is only one download link.