### PR TITLE
extend primary partition to use template.json

### DIFF
--- a/answer_files/2008_r2/Autounattend.xml
+++ b/answer_files/2008_r2/Autounattend.xml
@@ -9,7 +9,7 @@
                         <CreatePartition wcm:action="add">
                             <Order>1</Order>
                             <Type>Primary</Type>
-                            <Size>60000</Size>
+                            <Extend>true</Extend>
                         </CreatePartition>
                     </CreatePartitions>
                     <ModifyPartitions>

--- a/answer_files/2008_r2_core/Autounattend.xml
+++ b/answer_files/2008_r2_core/Autounattend.xml
@@ -9,7 +9,7 @@
                         <CreatePartition wcm:action="add">
                             <Order>1</Order>
                             <Type>Primary</Type>
-                            <Size>60000</Size>
+                            <Extend>true</Extend>
                         </CreatePartition>
                     </CreatePartitions>
                     <ModifyPartitions>

--- a/answer_files/2012/Autounattend.xml
+++ b/answer_files/2012/Autounattend.xml
@@ -9,7 +9,7 @@
                         <CreatePartition wcm:action="add">
                             <Order>1</Order>
                             <Type>Primary</Type>
-                            <Size>60000</Size>
+                            <Extend>true</Extend>
                         </CreatePartition>
                     </CreatePartitions>
                     <ModifyPartitions>

--- a/answer_files/7/Autounattend.xml
+++ b/answer_files/7/Autounattend.xml
@@ -9,7 +9,7 @@
                         <CreatePartition wcm:action="add">
                             <Order>1</Order>
                             <Type>Primary</Type>
-                            <Size>60000</Size>
+                            <Extend>true</Extend>
                         </CreatePartition>
                     </CreatePartitions>
                     <ModifyPartitions>

--- a/answer_files/81/Autounattend.xml
+++ b/answer_files/81/Autounattend.xml
@@ -9,7 +9,7 @@
                         <CreatePartition wcm:action="add">
                             <Order>1</Order>
                             <Type>Primary</Type>
-                            <Size>60000</Size>
+                            <Extend>true</Extend>
                         </CreatePartition>
                     </CreatePartitions>
                     <ModifyPartitions>


### PR DESCRIPTION
If we use the `<Extend>true</Extend>` tag in the `Autounattend.xml` files, then there only is one place to change disk size of the basebox: the template JSON files.

I once had the trouble to increase packer's `disk_size` in the template JSON file, but found out that the VM still only got 60GByte.

This time targeting develop branch. (This is my most wanted feature at GitHub that a maintainer could preselect the base branch for PR's independently to the [default branch](https://help.github.com/articles/setting-the-default-branch/) to be displayed on the Web.)
