### PR TITLE
disable auto updates for win-updates

### DIFF
--- a/answer_files/7/Autounattend.xml
+++ b/answer_files/7/Autounattend.xml
@@ -250,9 +250,14 @@
                 <!-- END WITHOUT WINDOWS UPDATES -->
                 <!-- WITH WINDOWS UPDATES -->
                 <!-- Disable automatic updates so the system update process doesn't interfere with the update script -->
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\dis-updates.ps1 -MaxUpdatesPerCycle 30</CommandLine>
+                    <Description>Disable Windows Auto-Updates</Description>
+                    <Order>98</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c a:\microsoft-updates.bat</CommandLine>
-                    <Order>98</Order>
+                    <Order>99</Order>
                     <Description>Enable Microsoft Updates</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">


### PR DESCRIPTION
If this is win auto updates is not disabled first, the applying of updates can interfere with the auto updates.

This fixes the "lock/hang" or 'interfering' condition I experienced in #126 that kept it from finnishing it's build.