### PR TITLE
Fix incorrect ProductKey XML for Windows 8.1.

### DIFF
--- a/answer_files/81/Autounattend.xml
+++ b/answer_files/81/Autounattend.xml
@@ -31,8 +31,9 @@
                 <AcceptEula>true</AcceptEula>
                 <FullName>Vagrant Administrator</FullName>
                 <Organization>Vagrant Inc.</Organization>
-                <!-- Product Key from http://technet.microsoft.com/en-us/library/ff793406.aspx -->
-                <ProductKey>XC9B7-NBPP2-83J2H-RHMBY-92BT4
+                <ProductKey>
+                    <!-- Product Key from http://technet.microsoft.com/en-us/library/ff793406.aspx -->
+                    <!--<Key>XC9B7-NBPP2-83J2H-RHMBY-92BT4</Key>-->
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
             </UserData>


### PR DESCRIPTION
When I went to add an actual ProductKey for Windows 8.1 I noticed that the XML appears to be incorrect. I changed it to match the other `Autounattend.xml` files in the project.