### PR TITLE
Define MaxUpdatesPerCycle for updates on 2008 R2 builds

### DIFF
--- a/answer_files/2008_r2/Autounattend.xml
+++ b/answer_files/2008_r2/Autounattend.xml
@@ -248,7 +248,7 @@
                     <Description>Enable Microsoft Updates</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1</CommandLine>
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1 -MaxUpdatesPerCycle 30</CommandLine>
                     <Description>Install Windows Updates</Description>
                     <Order>100</Order>
                     <RequiresUserInput>true</RequiresUserInput>


### PR DESCRIPTION
Previously, the 2008 R2 build would time out due to an unidentified
problem during the update process. It seems that limiting the number
of updates applied at once solves the problem.

Until the problem is identified and a proper fix formed, the
Autounattend scripts for 2008 R2 has been updated to make use of this
workaround. The problem persists with 2008 R2 Core even with this
addition.

--------------

Issue described in #134