### PR TITLE
Upgrades OpenSSH to 6.7p1-2

### DIFF
--- a/scripts/openssh.ps1
+++ b/scripts/openssh.ps1
@@ -6,11 +6,7 @@ Write-Host "AutoStart: $AutoStart"
 $is_64bit = [IntPtr]::size -eq 8
 
 # setup openssh
-$ssh_download_url = "http://www.mls-software.com/files/setupssh-6.6p1-1.exe"
-if ($is_64bit) {
-    Write-Host "64 bit OS found"
-    $ssh_download_url = "http://www.mls-software.com/files/setupssh-6.6p1-1(x64).exe"
-}
+$ssh_download_url = "http://www.mls-software.com/files/setupssh-6.7p1-2.exe"
 
 if (!(Test-Path "C:\Program Files\OpenSSH\bin\ssh.exe")) {
     Write-Host "Downloading $ssh_download_url"


### PR DESCRIPTION
The mls-software.com site lists several updates for OpenSSH 6.6 (the version that this repository currently uses) some of which address critical issues such as Shellshock. I've tested OpenSSH 6.7p1-2 with Windows 8.1 and can confirm that the provisioning steps complete as expected. There also seems to be just one installer now that targets both 32 and 64 bit platforms.