### PR TITLE
Update template to Windows 10 Inside Preview Build 10074

### DIFF
--- a/answer_files/10/Autounattend.xml
+++ b/answer_files/10/Autounattend.xml
@@ -46,7 +46,7 @@
                 -->
 
                 <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
-                <ProductKey>NKJFK-GPHP7-G8C3J-P6JXR-HQRJR
+                <ProductKey>6P99N-YF42M-TPGBG-9VMJP-YKHCF
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
             </UserData>
@@ -61,7 +61,7 @@
                     <InstallFrom>
                         <MetaData wcm:action="add">
                             <Key>/IMAGE/NAME</Key>
-                            <Value>Windows 8.1 Pro</Value>
+                            <Value>Windows 10 Pro Technical Preview</Value>
                         </MetaData>
                     </InstallFrom>
                 </OSImage>

--- a/windows_10.json
+++ b/windows_10.json
@@ -2,9 +2,9 @@
   "builders": [
     {
       "type": "vmware-iso",
-      "iso_url": "http://iso.esd.microsoft.com/W9TPI/B6B0A0278A90510669EAB90ABF80B22A/Windows10_TechnicalPreview_x64_EN-US_9926.iso",
+      "iso_url": "http://iso.esd.microsoft.com/W10IP/E0F85BFCD0F6BA607BF1528926371D21F8F6B6BF/Windows10_InsiderPreview_x64_EN-US_10074.iso",
       "iso_checksum_type": "sha1",
-      "iso_checksum": "6A95316728299D95249A29FBEB9676DED23B8BEB",
+      "iso_checksum": "E354B44994B46FB7CDC295FA1F075D9F95FECEA8",
       "headless": false,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -32,9 +32,9 @@
     },
     {
       "type": "virtualbox-iso",
-      "iso_url": "http://iso.esd.microsoft.com/W9TPI/B6B0A0278A90510669EAB90ABF80B22A/Windows10_TechnicalPreview_x64_EN-US_9926.iso",
+      "iso_url": "http://iso.esd.microsoft.com/W10IP/E0F85BFCD0F6BA607BF1528926371D21F8F6B6BF/Windows10_InsiderPreview_x64_EN-US_10074.iso",
       "iso_checksum_type": "sha1",
-      "iso_checksum": "6A95316728299D95249A29FBEB9676DED23B8BEB",
+      "iso_checksum": "E354B44994B46FB7CDC295FA1F075D9F95FECEA8",
       "headless": false,
       "boot_wait": "2m",
       "ssh_username": "vagrant",


### PR DESCRIPTION
I had some minutes and updated the `windows_10.json` template to the new ISO file to catch the new Build 10074.

The update script might hang once while trying to reboot the VM. If others have the same issue we have to dig deeper here.

Have fun!

One interesting thing. The new download link has the folder "W10IP", the old one was "W9TPI". So maybe the first plan was to release a Windows "9" ;-)
