### PR TITLE
Windows 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The following Windows versions are known to work (built with VMware Fusion 6.0.4
  * Windows 2012
  * Windows 2008 R2
  * Windows 2008 R2 Core
+ * Windows 10
  * Windows 8.1
  * Windows 7
 

--- a/answer_files/10/Autounattend.xml
+++ b/answer_files/10/Autounattend.xml
@@ -46,8 +46,7 @@
                 -->
 
                 <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
-                <ProductKey>
-                    <Key>8N67H-M3CY9-QT7C4-2TR7M-TXYCV</Key>
+                <ProductKey>NPPR9-FWDCX-D2C8J-H872K-2YT43
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
             </UserData>
@@ -62,7 +61,7 @@
                     <InstallFrom>
                         <MetaData wcm:action="add">
                             <Key>/IMAGE/NAME</Key>
-                            <Value>Windows 10 Pro Technical Preview</Value>
+                            <Value>Windows 10 Enterprise Evaluation</Value>
                         </MetaData>
                     </InstallFrom>
                 </OSImage>

--- a/answer_files/10/Autounattend.xml
+++ b/answer_files/10/Autounattend.xml
@@ -33,7 +33,7 @@
                 <Organization>Vagrant Inc.</Organization>
 
                 <!--
-                    NOTE: If you are re-configuring this for use of a retail key 
+                    NOTE: If you are re-configuring this for use of a retail key
                     and using a retail ISO, you need to adjust the <ProductKey> block
                     below to look like this:
 
@@ -46,7 +46,8 @@
                 -->
 
                 <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
-                <ProductKey>6P99N-YF42M-TPGBG-9VMJP-YKHCF
+                <ProductKey>
+                    <Key>8N67H-M3CY9-QT7C4-2TR7M-TXYCV</Key>
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
             </UserData>

--- a/windows_10.json
+++ b/windows_10.json
@@ -2,9 +2,9 @@
   "builders": [
     {
       "type": "vmware-iso",
-      "iso_url": "http://iso.esd.microsoft.com/W10IP/E0F85BFCD0F6BA607BF1528926371D21F8F6B6BF/Windows10_InsiderPreview_x64_EN-US_10074.iso",
+      "iso_url": "http://iso.esd.microsoft.com/W10IP/4B33E0680A465FBA52C09A34454D5EB6/Windows10_InsiderPreview_x64_EN-US_10162.iso",
       "iso_checksum_type": "sha1",
-      "iso_checksum": "E354B44994B46FB7CDC295FA1F075D9F95FECEA8",
+      "iso_checksum": "31346458255AFEAC1AFEED5C4C61F15D57708B9B",
       "headless": false,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -32,9 +32,9 @@
     },
     {
       "type": "virtualbox-iso",
-      "iso_url": "http://iso.esd.microsoft.com/W10IP/E0F85BFCD0F6BA607BF1528926371D21F8F6B6BF/Windows10_InsiderPreview_x64_EN-US_10074.iso",
+      "iso_url": "http://iso.esd.microsoft.com/W10IP/4B33E0680A465FBA52C09A34454D5EB6/Windows10_InsiderPreview_x64_EN-US_10162.iso",
       "iso_checksum_type": "sha1",
-      "iso_checksum": "E354B44994B46FB7CDC295FA1F075D9F95FECEA8",
+      "iso_checksum": "31346458255AFEAC1AFEED5C4C61F15D57708B9B",
       "headless": false,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -63,6 +63,19 @@
           "--cpus",
           "2"
         ]
+      ]
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "remote_path": "/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
+      "scripts": [
+        "./scripts/vm-guest-tools.bat",
+        "./scripts/vagrant-ssh.bat",
+        "./scripts/enable-rdp.bat",
+        "./scripts/compact.bat"
       ]
     }
   ],

--- a/windows_10.json
+++ b/windows_10.json
@@ -2,9 +2,9 @@
   "builders": [
     {
       "type": "vmware-iso",
-      "iso_url": "http://iso.esd.microsoft.com/W10IP/4B33E0680A465FBA52C09A34454D5EB6/Windows10_InsiderPreview_x64_EN-US_10162.iso",
+      "iso_url": "http://care.dlservice.microsoft.com/dl/download/C/3/9/C399EEA8-135D-4207-92C9-6AAB3259F6EF/10240.16384.150709-1700.TH1_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
       "iso_checksum_type": "sha1",
-      "iso_checksum": "31346458255AFEAC1AFEED5C4C61F15D57708B9B",
+      "iso_checksum": "56ab095075be28a90bc0b510835280975c6bb2ce",
       "headless": false,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -32,9 +32,9 @@
     },
     {
       "type": "virtualbox-iso",
-      "iso_url": "http://iso.esd.microsoft.com/W10IP/4B33E0680A465FBA52C09A34454D5EB6/Windows10_InsiderPreview_x64_EN-US_10162.iso",
+      "iso_url": "http://care.dlservice.microsoft.com/dl/download/C/3/9/C399EEA8-135D-4207-92C9-6AAB3259F6EF/10240.16384.150709-1700.TH1_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
       "iso_checksum_type": "sha1",
-      "iso_checksum": "31346458255AFEAC1AFEED5C4C61F15D57708B9B",
+      "iso_checksum": "56ab095075be28a90bc0b510835280975c6bb2ce",
       "headless": false,
       "boot_wait": "2m",
       "ssh_username": "vagrant",


### PR DESCRIPTION
I've updated the windows_10.json template to build Windows 10 technical preview build 10162.
Now also shell provisioning seems to work again, so I have added some of them.
Tested with packer 0.8.1 with Fusion 7 on OSX 10.10.3 (packer is still compacting the disk...).

Nice new wallpaper :+1: 

<img width="683" alt="bildschirmfoto 2015-07-03 um 16 12 08" src="https://cloud.githubusercontent.com/assets/207759/8500758/63000a2c-219f-11e5-8ee9-749c8c69f06c.png">
