### PR TITLE
Increase MaxMemoryPerShellMB to 800 to fix WinRM provisioning problems

### DIFF
--- a/answer_files/10/Autounattend.xml
+++ b/answer_files/10/Autounattend.xml
@@ -161,7 +161,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="300"}</CommandLine>
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="800"}</CommandLine>
                     <Description>Win RM MaxMemoryPerShellMB</Description>
                     <Order>8</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2008_r2/Autounattend.xml
+++ b/answer_files/2008_r2/Autounattend.xml
@@ -137,7 +137,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="300"}</CommandLine>
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="800"}</CommandLine>
                     <Description>Win RM MaxMemoryPerShellMB</Description>
                     <Order>6</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2008_r2_core/Autounattend.xml
+++ b/answer_files/2008_r2_core/Autounattend.xml
@@ -173,7 +173,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="300"}</CommandLine>
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="800"}</CommandLine>
                     <Description>Win RM MaxMemoryPerShellMB</Description>
                     <Order>12</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2012/Autounattend.xml
+++ b/answer_files/2012/Autounattend.xml
@@ -142,7 +142,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="300"}</CommandLine>
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="800"}</CommandLine>
                     <Description>Win RM MaxMemoryPerShellMB</Description>
                     <Order>6</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2012_r2/Autounattend.xml
+++ b/answer_files/2012_r2/Autounattend.xml
@@ -139,7 +139,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="300"}</CommandLine>
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="800"}</CommandLine>
                     <Description>Win RM MaxMemoryPerShellMB</Description>
                     <Order>6</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2012_r2_core/Autounattend.xml
+++ b/answer_files/2012_r2_core/Autounattend.xml
@@ -139,7 +139,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="300"}</CommandLine>
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="800"}</CommandLine>
                     <Description>Win RM MaxMemoryPerShellMB</Description>
                     <Order>6</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2012_r2_hyperv/Autounattend.xml
+++ b/answer_files/2012_r2_hyperv/Autounattend.xml
@@ -139,7 +139,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="300"}</CommandLine>
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="800"}</CommandLine>
                     <Description>Win RM MaxMemoryPerShellMB</Description>
                     <Order>6</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/7/Autounattend.xml
+++ b/answer_files/7/Autounattend.xml
@@ -138,7 +138,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="300"}</CommandLine>
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="800"}</CommandLine>
                     <Description>Win RM MaxMemoryPerShellMB</Description>
                     <Order>6</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/81/Autounattend.xml
+++ b/answer_files/81/Autounattend.xml
@@ -149,7 +149,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="300"}</CommandLine>
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="800"}</CommandLine>
                     <Description>Win RM MaxMemoryPerShellMB</Description>
                     <Order>6</Order>
                     <RequiresUserInput>true</RequiresUserInput>


### PR DESCRIPTION
I have just seen that we still use only 300MB for the `MaxMemoryPerShellMB` entry. This PR will increase it to 800MB. This solves a lot of OutOfMemory errors while provisioning the Vagrant box with Chocolatey etc.
