### PR TITLE
Use variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,30 @@ WinRM to communicate with the box.
 
 Trial versions of Windows 2008 R2 / 2012 / 2012 R2 are used by default. These images can be used for 180 days without activation.
 
-Alternatively – if you have access to [MSDN](http://msdn.microsoft.com) or [TechNet](http://technet.microsoft.com/) – you can download retail or volume license ISO images and place them in the `iso` directory. If you do, you should update the relevent `.json` file, setting `iso_url` to `./iso/<path to your iso>.iso` and `iso_checksum` to `<the md5 of your iso>`. For example, to use the Windows 2008 R2 (With SP1) retail ISO:
+Alternatively – if you have access to [MSDN](http://msdn.microsoft.com) or [TechNet](http://technet.microsoft.com/) – you can download retail or volume license ISO images and place them in the `iso` directory. If you do, you should supply appropriate values for `iso_url` (e.g. `./iso/<path to your iso>.iso`) and `iso_checksum` (e.g. `<the md5 of your iso>`) to the Packer command. For example, to use the Windows 2008 R2 (With SP1) retail ISO:
 
 1. Download the Windows Server 2008 R2 with Service Pack 1 (x64) - DVD (English) ISO (`en_windows_server_2008_r2_with_sp1_x64_dvd_617601.iso`)
 2. Verify that `en_windows_server_2008_r2_with_sp1_x64_dvd_617601.iso` has an MD5 hash of `8dcde01d0da526100869e2457aafb7ca` (Microsoft lists a SHA1 hash of `d3fd7bf85ee1d5bdd72de5b2c69a7b470733cd0a`, which is equivalent)
 3. Clone this repo to a local directory
 4. Move `en_windows_server_2008_r2_with_sp1_x64_dvd_617601.iso` to the `iso` directory
-5. Update `windows_2008_r2.json`, setting `iso_url` to `./iso/en_windows_server_2008_r2_with_sp1_x64_dvd_617601.iso`
-6. Update `windows_2008_r2.json`, setting `iso_checksum` to `8dcde01d0da526100869e2457aafb7ca`
-7. Run `packer build windows_2008_r2.json`
+5. Run:
+    
+    ```
+    packer build \
+        -var iso_url=./iso/en_windows_server_2008_r2_with_sp1_x64_dvd_617601.iso \
+        -var iso_checksum=8dcde01d0da526100869e2457aafb7ca windows_2008_r2.json
+    ```
+
+### Variables
+
+The Packer templates support the following variables:
+
+| Name                | Description                                                      |
+| --------------------|------------------------------------------------------------------|
+| `iso_url`           | Path or URL to ISO file                                          |
+| `iso_checksum`      | Checksum (see also `iso_checksum_type`) of the ISO file          |
+| `iso_checksum_type` | The checksum algorithm to use (out of those supported by Packer) |
+| `autounattend`      | Path to the Autounattend.xml file                                |
 
 ### Contributing
 

--- a/windows_10.json
+++ b/windows_10.json
@@ -2,9 +2,9 @@
   "builders": [
     {
       "type": "vmware-iso",
-      "iso_url": "http://care.dlservice.microsoft.com/dl/download/C/3/9/C399EEA8-135D-4207-92C9-6AAB3259F6EF/10240.16384.150709-1700.TH1_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
-      "iso_checksum_type": "sha1",
-      "iso_checksum": "56ab095075be28a90bc0b510835280975c6bb2ce",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": false,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -17,7 +17,7 @@
       "vnc_port_min": 5900,
       "vnc_port_max": 5980,
       "floppy_files": [
-        "./answer_files/10/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/fixnetwork.ps1",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
@@ -33,9 +33,9 @@
     },
     {
       "type": "virtualbox-iso",
-      "iso_url": "http://care.dlservice.microsoft.com/dl/download/C/3/9/C399EEA8-135D-4207-92C9-6AAB3259F6EF/10240.16384.150709-1700.TH1_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
-      "iso_checksum_type": "sha1",
-      "iso_checksum": "56ab095075be28a90bc0b510835280975c6bb2ce",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": false,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -45,7 +45,7 @@
       "guest_os_type": "Windows81_64",
       "disk_size": 61440,
       "floppy_files": [
-        "./answer_files/10/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/fixnetwork.ps1",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
@@ -88,5 +88,11 @@
       "output": "windows_10_{{.Provider}}.box",
       "vagrantfile_template": "vagrantfile-windows_10.template"
     }
-  ]
+  ],
+  "variables": {
+    "iso_url": "http://care.dlservice.microsoft.com/dl/download/C/3/9/C399EEA8-135D-4207-92C9-6AAB3259F6EF/10240.16384.150709-1700.TH1_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
+    "iso_checksum_type": "sha1",
+    "iso_checksum": "56ab095075be28a90bc0b510835280975c6bb2ce",
+    "autounattend": "./answer_files/10/Autounattend.xml"
+  }
 }

--- a/windows_2008_r2.json
+++ b/windows_2008_r2.json
@@ -2,9 +2,9 @@
   "builders": [
     {
       "type": "vmware-iso",
-      "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "4263be2cf3c59177c45085c0a7bc6ca5",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -17,7 +17,7 @@
       "vnc_port_min": 5900,
       "vnc_port_max": 5980,
       "floppy_files": [
-        "./answer_files/2008_r2/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1"
@@ -32,9 +32,9 @@
     },
     {
       "type": "virtualbox-iso",
-      "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "4263be2cf3c59177c45085c0a7bc6ca5",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -44,7 +44,7 @@
       "guest_os_type": "Windows2008_64",
       "disk_size": 61440,
       "floppy_files": [
-        "./answer_files/2008_r2/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1",
@@ -94,5 +94,11 @@
       "output": "windows_2008_r2_{{.Provider}}.box",
       "vagrantfile_template": "vagrantfile-windows_2008_r2.template"
     }
-  ]
+  ],
+  "variables": {
+    "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
+    "iso_checksum_type": "md5",
+    "iso_checksum": "4263be2cf3c59177c45085c0a7bc6ca5",
+    "autounattend": "./answer_files/2008_r2/Autounattend.xml"
+  }
 }

--- a/windows_2008_r2_core.json
+++ b/windows_2008_r2_core.json
@@ -2,9 +2,9 @@
   "builders": [
     {
       "type": "vmware-iso",
-      "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "4263be2cf3c59177c45085c0a7bc6ca5",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -17,7 +17,7 @@
       "vnc_port_min": 5900,
       "vnc_port_max": 5980,
       "floppy_files": [
-        "./answer_files/2008_r2_core/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1"
@@ -32,9 +32,9 @@
     },
     {
       "type": "virtualbox-iso",
-      "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "4263be2cf3c59177c45085c0a7bc6ca5",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -44,7 +44,7 @@
       "guest_os_type": "Windows2008_64",
       "disk_size": 61440,
       "floppy_files": [
-        "./answer_files/2008_r2_core/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1",
@@ -94,5 +94,11 @@
       "output": "windows_2008_r2_core_{{.Provider}}.box",
       "vagrantfile_template": "vagrantfile-windows_2008_r2.template"
     }
-  ]
+  ],
+  "variables": {
+    "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
+    "iso_checksum_type": "md5",
+    "iso_checksum": "4263be2cf3c59177c45085c0a7bc6ca5",
+    "autounattend": "./answer_files/2008_r2_core/Autounattend.xml"
+  }
 }

--- a/windows_2012.json
+++ b/windows_2012.json
@@ -2,9 +2,9 @@
   "builders": [
     {
       "type": "vmware-iso",
-      "iso_url": "http://download.microsoft.com/download/6/D/A/6DAB58BA-F939-451D-9101-7DE07DC09C03/9200.16384.WIN8_RTM.120725-1247_X64FRE_SERVER_EVAL_EN-US-HRM_SSS_X64FREE_EN-US_DV5.ISO",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "8503997171f731d9bd1cb0b0edc31f3d",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -17,7 +17,7 @@
       "vnc_port_min": 5900,
       "vnc_port_max": 5980,
       "floppy_files": [
-        "./answer_files/2012/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1"
@@ -32,9 +32,9 @@
     },
     {
       "type": "virtualbox-iso",
-      "iso_url": "http://download.microsoft.com/download/6/D/A/6DAB58BA-F939-451D-9101-7DE07DC09C03/9200.16384.WIN8_RTM.120725-1247_X64FRE_SERVER_EVAL_EN-US-HRM_SSS_X64FREE_EN-US_DV5.ISO",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "8503997171f731d9bd1cb0b0edc31f3d",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -44,7 +44,7 @@
       "guest_os_type": "Windows2012_64",
       "disk_size": 61440,
       "floppy_files": [
-        "./answer_files/2012/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1",
@@ -93,5 +93,11 @@
       "output": "windows_2012_{{.Provider}}.box",
       "vagrantfile_template": "vagrantfile-windows_2012.template"
     }
-  ]
+  ],
+  "variables": {
+    "iso_url": "http://download.microsoft.com/download/6/D/A/6DAB58BA-F939-451D-9101-7DE07DC09C03/9200.16384.WIN8_RTM.120725-1247_X64FRE_SERVER_EVAL_EN-US-HRM_SSS_X64FREE_EN-US_DV5.ISO",
+    "iso_checksum_type": "md5",
+    "iso_checksum": "8503997171f731d9bd1cb0b0edc31f3d",
+    "autounattend": "./answer_files/2012/Autounattend.xml"
+  }
 }

--- a/windows_2012_r2.json
+++ b/windows_2012_r2.json
@@ -2,9 +2,9 @@
   "builders": [
     {
       "type": "vmware-iso",
-      "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_SERVER_EVAL_EN-US-IRM_SSS_X64FREE_EN-US_DV5.ISO",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "458ff91f8abc21b75cb544744bf92e6a",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -17,7 +17,7 @@
       "vnc_port_min": 5900,
       "vnc_port_max": 5980,
       "floppy_files": [
-        "./answer_files/2012_r2/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1"
@@ -32,9 +32,9 @@
     },
     {
       "type": "virtualbox-iso",
-      "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_SERVER_EVAL_EN-US-IRM_SSS_X64FREE_EN-US_DV5.ISO",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "458ff91f8abc21b75cb544744bf92e6a",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -44,7 +44,7 @@
       "guest_os_type": "Windows2012_64",
       "disk_size": 61440,
       "floppy_files": [
-        "./answer_files/2012_r2/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1",
@@ -95,5 +95,11 @@
       "output": "windows_2012_r2_{{.Provider}}.box",
       "vagrantfile_template": "vagrantfile-windows_2012_r2.template"
     }
-  ]
+  ],
+  "variables": {
+    "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_SERVER_EVAL_EN-US-IRM_SSS_X64FREE_EN-US_DV5.ISO",
+    "iso_checksum_type": "md5",
+    "iso_checksum": "458ff91f8abc21b75cb544744bf92e6a",
+    "autounattend": "./answer_files/2012_r2/Autounattend.xml"
+  }
 }

--- a/windows_2012_r2_core.json
+++ b/windows_2012_r2_core.json
@@ -2,9 +2,9 @@
   "builders": [
     {
       "type": "vmware-iso",
-      "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_SERVER_EVAL_EN-US-IRM_SSS_X64FREE_EN-US_DV5.ISO",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "458ff91f8abc21b75cb544744bf92e6a",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -17,7 +17,7 @@
       "vnc_port_min": 5900,
       "vnc_port_max": 5980,
       "floppy_files": [
-        "./answer_files/2012_r2_core/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1"
@@ -32,9 +32,9 @@
     },
     {
       "type": "virtualbox-iso",
-      "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_SERVER_EVAL_EN-US-IRM_SSS_X64FREE_EN-US_DV5.ISO",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "458ff91f8abc21b75cb544744bf92e6a",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -44,7 +44,7 @@
       "guest_os_type": "Windows2012_64",
       "disk_size": 61440,
       "floppy_files": [
-        "./answer_files/2012_r2_core/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1",
@@ -95,5 +95,11 @@
       "output": "windows_2012_r2_core_{{.Provider}}.box",
       "vagrantfile_template": "vagrantfile-windows_2012_r2.template"
     }
-  ]
+  ],
+  "variables": {
+    "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_SERVER_EVAL_EN-US-IRM_SSS_X64FREE_EN-US_DV5.ISO",
+    "iso_checksum_type": "md5",
+    "iso_checksum": "458ff91f8abc21b75cb544744bf92e6a",
+    "autounattend": "./answer_files/2012_r2_core/Autounattend.xml"
+  }
 }

--- a/windows_2012_r2_hyperv.json
+++ b/windows_2012_r2_hyperv.json
@@ -2,9 +2,9 @@
   "builders": [
     {
       "type": "vmware-iso",
-      "iso_url": "http://care.dlservice.microsoft.com/dl/download/F/7/D/F7DF966B-5C40-4674-9A32-D83D869A3244/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_SERVERHYPERCORE_EN-US-IRM_SHV_X64FRE_EN-US_DV5.ISO",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "9c9e0d82cb6301a4b88fd2f4c35caf80",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -17,7 +17,7 @@
       "vnc_port_min": 5900,
       "vnc_port_max": 5980,
       "floppy_files": [
-        "./answer_files/2012_r2_hyperv/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1"
@@ -32,9 +32,9 @@
     },
     {
       "type": "virtualbox-iso",
-      "iso_url": "http://care.dlservice.microsoft.com/dl/download/F/7/D/F7DF966B-5C40-4674-9A32-D83D869A3244/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_SERVERHYPERCORE_EN-US-IRM_SHV_X64FRE_EN-US_DV5.ISO",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "9c9e0d82cb6301a4b88fd2f4c35caf80",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -44,7 +44,7 @@
       "guest_os_type": "Windows2012_64",
       "disk_size": 61440,
       "floppy_files": [
-        "./answer_files/2012_r2_hyperv/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1",
@@ -95,5 +95,11 @@
       "output": "windows_2012_r2_hyperv_{{.Provider}}.box",
       "vagrantfile_template": "vagrantfile-windows_2012_r2.template"
     }
-  ]
+  ],
+  "variables": {
+    "iso_url": "http://care.dlservice.microsoft.com/dl/download/F/7/D/F7DF966B-5C40-4674-9A32-D83D869A3244/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_SERVERHYPERCORE_EN-US-IRM_SHV_X64FRE_EN-US_DV5.ISO",
+    "iso_checksum_type": "md5",
+    "iso_checksum": "9c9e0d82cb6301a4b88fd2f4c35caf80",
+    "autounattend": "./answer_files/2012_r2_hyperv/Autounattend.xml"
+  }
 }

--- a/windows_7.json
+++ b/windows_7.json
@@ -2,9 +2,9 @@
   "builders": [
     {
       "type": "vmware-iso",
-      "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "1d0d239a252cb53e466d39e752b17c28",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -17,7 +17,7 @@
       "vnc_port_min": 5900,
       "vnc_port_max": 5980,
       "floppy_files": [
-        "./answer_files/7/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/dis-updates.ps1",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
@@ -33,9 +33,9 @@
     },
     {
       "type": "virtualbox-iso",
-      "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "1d0d239a252cb53e466d39e752b17c28",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -45,7 +45,7 @@
       "guest_os_type": "Windows7_64",
       "disk_size": 61440,
       "floppy_files": [
-        "./answer_files/7/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/dis-updates.ps1",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
@@ -91,5 +91,11 @@
       "output": "windows_7_{{.Provider}}.box",
       "vagrantfile_template": "vagrantfile-windows_7.template"
     }
-  ]
+  ],
+  "variables": {
+    "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
+    "iso_checksum_type": "md5",
+    "iso_checksum": "1d0d239a252cb53e466d39e752b17c28",
+    "autounattend": "./answer_files/7/Autounattend.xml"
+  }
 }

--- a/windows_81.json
+++ b/windows_81.json
@@ -2,9 +2,9 @@
   "builders": [
     {
       "type": "vmware-iso",
-      "iso_url": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_ENTERPRISE_EVAL_EN-US-IRM_CENA_X64FREE_EN-US_DV5.ISO",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "5e4ecb86fd8619641f1d58f96e8561ec",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -17,7 +17,7 @@
       "vnc_port_min": 5900,
       "vnc_port_max": 5980,
       "floppy_files": [
-        "./answer_files/81/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1"
@@ -32,9 +32,9 @@
     },
     {
       "type": "virtualbox-iso",
-      "iso_url": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_ENTERPRISE_EVAL_EN-US-IRM_CENA_X64FREE_EN-US_DV5.ISO",
-      "iso_checksum_type": "md5",
-      "iso_checksum": "5e4ecb86fd8619641f1d58f96e8561ec",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": true,
       "boot_wait": "2m",
       "ssh_username": "vagrant",
@@ -44,7 +44,7 @@
       "guest_os_type": "Windows81_64",
       "disk_size": 61440,
       "floppy_files": [
-        "./answer_files/81/Autounattend.xml",
+        "{{user `autounattend`}}",
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1",
@@ -95,5 +95,11 @@
       "output": "windows_81_{{.Provider}}.box",
       "vagrantfile_template": "vagrantfile-windows_81.template"
     }
-  ]
+  ],
+  "variables": {
+    "iso_url": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_ENTERPRISE_EVAL_EN-US-IRM_CENA_X64FREE_EN-US_DV5.ISO",
+    "iso_checksum_type": "md5",
+    "iso_checksum": "5e4ecb86fd8619641f1d58f96e8561ec",
+    "autounattend": "./answer_files/81/Autounattend.xml"
+  }
 }


### PR DESCRIPTION
Instead of relying on manual editing of templates, make use of Packer's support for variables.

The following variables have been implemented across all templates:

* iso_url
* iso_checksum_type
* iso_checksum
* path to Autounattend.xml

Example usage:

`packer build -var iso_url=my.iso -var iso_checksum=deadbeef template.json`