### PR TITLE
Update windows_81.json

### DIFF
--- a/windows_81.json
+++ b/windows_81.json
@@ -84,7 +84,7 @@
     {
       "type": "shell",
       "inline": [
-        "rm -rf /tmp/*"
+        "rm -rf /tmp/* || ! false"
       ]
     }
   ],


### PR DESCRIPTION
Addresses https://github.com/joefitzgerald/packer-windows/issues/80 (rm: cannot remove '/tmp/TMPXXXXXXXX': Device or resource busy) for Windows 8.1