### PR TITLE
Fix 2012_r2_hyperv image selection

### DIFF
--- a/answer_files/2012_r2_hyperv/Autounattend.xml
+++ b/answer_files/2012_r2_hyperv/Autounattend.xml
@@ -51,7 +51,7 @@
                     <InstallFrom>
                         <MetaData wcm:action="add">
                             <Key>/IMAGE/NAME </Key>
-                            <Value>Windows Server 2012 R2 SERVERHYPERCORE</Value>
+                            <Value>Hyper-V Server 2012 R2 SERVERHYPERCORE</Value>
                         </MetaData>
                     </InstallFrom>
                     <InstallTo>


### PR DESCRIPTION
'Hyper-V Server 2012 R2 SERVERHYPERCORE' appears to be the correct image name for 2012 R2 Hyper-V. Without it the build process stops and waits for you to select an image.