### PR TITLE
Fix Windows 7 builds that use Windows Updates

### DIFF
--- a/answer_files/7/Autounattend.xml
+++ b/answer_files/7/Autounattend.xml
@@ -237,7 +237,7 @@
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\dis-updates.ps1</CommandLine>
                     <Description>Disable Automatic Updates</Description>
-                    <Order>98</Order>
+                    <Order>96</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
@@ -252,12 +252,12 @@
                 <!-- Disable automatic updates so the system update process doesn't interfere with the update script -->
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c a:\hotfix-KB3102810.bat</CommandLine>
-                    <Order>96</Order>
+                    <Order>97</Order>
                     <Description>Install Windows Update Hotfix (KB3102810)</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c a:\microsoft-updates.bat</CommandLine>
-                    <Order>97</Order>
+                    <Order>98</Order>
                     <Description>Enable Microsoft Updates</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">

--- a/answer_files/7/Autounattend.xml
+++ b/answer_files/7/Autounattend.xml
@@ -232,14 +232,14 @@
                     <Order>22</Order>
                     <Description>Disable password expiration for vagrant user</Description>
                 </SynchronousCommand>
-                <!-- WITHOUT WINDOWS UPDATES -->
-                <!--
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\dis-updates.ps1</CommandLine>
                     <Description>Disable Automatic Updates</Description>
-                    <Order>97</Order>
+                    <Order>98</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
+                <!-- WITHOUT WINDOWS UPDATES -->
+                <!--
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\openssh.ps1 -AutoStart</CommandLine>
                     <Description>Install OpenSSH</Description>
@@ -252,11 +252,11 @@
                 <!-- Disable automatic updates so the system update process doesn't interfere with the update script -->
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c a:\microsoft-updates.bat</CommandLine>
-                    <Order>98</Order>
+                    <Order>97</Order>
                     <Description>Enable Microsoft Updates</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1 -MaxUpdatesPerCycle 30</CommandLine>
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1 -MaxUpdatesPerCycle 100 -RestartRequired 1</CommandLine>
                     <Description>Install Windows Updates</Description>
                     <Order>100</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/scripts/compile-dotnet-assemblies.bat
+++ b/scripts/compile-dotnet-assemblies.bat
@@ -10,4 +10,5 @@ if exist %windir%\microsoft.net\framework64\v4.0.30319\ngen.exe (
 	%windir%\microsoft.net\framework64\v4.0.30319\ngen.exe executequeueditems
 )
 
+:: continue even if ngen fails
 exit /b 0

--- a/scripts/compile-dotnet-assemblies.bat
+++ b/scripts/compile-dotnet-assemblies.bat
@@ -1,15 +1,11 @@
 ::http://support.microsoft.com/kb/2570538
 ::http://robrelyea.wordpress.com/2007/07/13/may-be-helpful-ngen-exe-executequeueditems/
 
-if "%PROCESSOR_ARCHITECTURE%"=="AMD64" goto 64BIT
-
-%windir%\microsoft.net\framework\v4.0.30319\ngen.exe update /force /queue
-%windir%\microsoft.net\framework\v4.0.30319\ngen.exe executequeueditems
-
-exit /b
-
-:64BIT
-%windir%\microsoft.net\framework\v4.0.30319\ngen.exe update /force /queue
-%windir%\microsoft.net\framework64\v4.0.30319\ngen.exe update /force /queue
-%windir%\microsoft.net\framework\v4.0.30319\ngen.exe executequeueditems
-%windir%\microsoft.net\framework64\v4.0.30319\ngen.exe executequeueditems
+if exist %windir%\microsoft.net\framework\v4.0.30319\ngen.exe (
+	%windir%\microsoft.net\framework\v4.0.30319\ngen.exe update /force /queue
+	%windir%\microsoft.net\framework\v4.0.30319\ngen.exe executequeueditems
+)
+if exist %windir%\microsoft.net\framework64\v4.0.30319\ngen.exe (
+	%windir%\microsoft.net\framework64\v4.0.30319\ngen.exe update /force /queue
+	%windir%\microsoft.net\framework64\v4.0.30319\ngen.exe executequeueditems
+)


### PR DESCRIPTION
Win7 post SP1 patch has around 270 updates currently, each cycle of updates can spend upwards of 40 minutes searching for updates so reduce number of update cycles reduces the build time. Windows update history shows some updates fail but were subsequently installed successfully.
win-updates.ps1 is interrupted by automatic updates so run dis-updates.ps1 first.