### PR TITLE
Add support of Parallels builder

### DIFF
--- a/windows_10.json
+++ b/windows_10.json
@@ -66,6 +66,50 @@
           "2"
         ]
       ]
+    },
+    {
+      "type": "parallels-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "2h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "guest_os_type": "win-10",
+      "parallels_tools_flavor": "win",
+      "disk_size": 61440,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/fixnetwork.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1",
+        "./scripts/oracle-cert.cer"
+      ],
+      "prlctl": [
+        [
+          "set", "{{.Name}}",
+          "--memsize", "2048"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--cpus", "2"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--winsystray-in-macmenu", "off"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--startup-view", "window"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--efi-boot", "off"
+        ]
+      ]
     }
   ],
   "provisioners": [

--- a/windows_2008_r2.json
+++ b/windows_2008_r2.json
@@ -64,6 +64,49 @@
           "2"
         ]
       ]
+    },
+    {
+      "type": "parallels-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "2h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "guest_os_type": "win-2008",
+      "parallels_tools_flavor": "win",
+      "disk_size": 61440,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1",
+        "./scripts/oracle-cert.cer"
+      ],
+      "prlctl": [
+        [
+          "set", "{{.Name}}",
+          "--memsize", "2048"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--cpus", "2"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--winsystray-in-macmenu", "off"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--startup-view", "window"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--efi-boot", "off"
+        ]
+      ]
     }
   ],
   "provisioners": [

--- a/windows_2008_r2_core.json
+++ b/windows_2008_r2_core.json
@@ -64,6 +64,49 @@
           "2"
         ]
       ]
+    },
+    {
+      "type": "parallels-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "2h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "guest_os_type": "win-2008",
+      "parallels_tools_flavor": "win",
+      "disk_size": 61440,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1",
+        "./scripts/oracle-cert.cer"
+      ],
+      "prlctl": [
+        [
+          "set", "{{.Name}}",
+          "--memsize", "2048"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--cpus", "2"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--winsystray-in-macmenu", "off"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--startup-view", "window"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--efi-boot", "off"
+        ]
+      ]
     }
   ],
   "provisioners": [

--- a/windows_2012.json
+++ b/windows_2012.json
@@ -64,6 +64,49 @@
           "2"
         ]
       ]
+    },
+    {
+      "type": "parallels-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "2h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "guest_os_type": "win-2012",
+      "parallels_tools_flavor": "win",
+      "disk_size": 61440,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1",
+        "./scripts/oracle-cert.cer"
+      ],
+      "prlctl": [
+        [
+          "set", "{{.Name}}",
+          "--memsize", "2048"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--cpus", "2"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--winsystray-in-macmenu", "off"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--startup-view", "window"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--efi-boot", "off"
+        ]
+      ]
     }
   ],
   "provisioners": [

--- a/windows_2012_r2.json
+++ b/windows_2012_r2.json
@@ -64,6 +64,49 @@
           "2"
         ]
       ]
+    },
+    {
+      "type": "parallels-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "6h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "guest_os_type": "win-2012",
+      "parallels_tools_flavor": "win",
+      "disk_size": 61440,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1",
+        "./scripts/oracle-cert.cer"
+      ],
+      "prlctl": [
+        [
+          "set", "{{.Name}}",
+          "--memsize", "2048"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--cpus", "2"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--winsystray-in-macmenu", "off"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--startup-view", "window"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--efi-boot", "off"
+        ]
+      ]
     }
   ],
   "provisioners": [

--- a/windows_2012_r2_core.json
+++ b/windows_2012_r2_core.json
@@ -64,6 +64,49 @@
           "2"
         ]
       ]
+    },
+    {
+      "type": "parallels-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "6h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "guest_os_type": "win-2012",
+      "parallels_tools_flavor": "win",
+      "disk_size": 61440,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1",
+        "./scripts/oracle-cert.cer"
+      ],
+      "prlctl": [
+        [
+          "set", "{{.Name}}",
+          "--memsize", "2048"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--cpus", "2"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--winsystray-in-macmenu", "off"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--startup-view", "window"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--efi-boot", "off"
+        ]
+      ]
     }
   ],
   "provisioners": [

--- a/windows_2012_r2_hyperv.json
+++ b/windows_2012_r2_hyperv.json
@@ -64,6 +64,49 @@
           "2"
         ]
       ]
+    },
+    {
+      "type": "parallels-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "6h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "guest_os_type": "win-2012",
+      "parallels_tools_flavor": "win",
+      "disk_size": 61440,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1",
+        "./scripts/oracle-cert.cer"
+      ],
+      "prlctl": [
+        [
+          "set", "{{.Name}}",
+          "--memsize", "2048"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--cpus", "2"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--winsystray-in-macmenu", "off"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--startup-view", "window"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--efi-boot", "off"
+        ]
+      ]
     }
   ],
   "provisioners": [

--- a/windows_7.json
+++ b/windows_7.json
@@ -68,6 +68,50 @@
           "2"
         ]
       ]
+    },
+    {
+      "type": "parallels-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "8h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "guest_os_type": "win-7",
+      "parallels_tools_flavor": "win",
+      "disk_size": 61440,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/dis-updates.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1",
+        "./scripts/oracle-cert.cer"
+      ],
+      "prlctl": [
+        [
+          "set", "{{.Name}}",
+          "--memsize", "2048"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--cpus", "2"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--winsystray-in-macmenu", "off"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--startup-view", "window"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--efi-boot", "off"
+        ]
+      ]
     }
   ],
   "provisioners": [

--- a/windows_81.json
+++ b/windows_81.json
@@ -64,6 +64,49 @@
           "2"
         ]
       ]
+    },
+    {
+      "type": "parallels-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "2h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "guest_os_type": "win-8.1",
+      "parallels_tools_flavor": "win",
+      "disk_size": 61440,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1",
+        "./scripts/oracle-cert.cer"
+      ],
+      "prlctl": [
+        [
+          "set", "{{.Name}}",
+          "--memsize", "2048"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--cpus", "2"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--winsystray-in-macmenu", "off"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--startup-view", "window"
+        ],
+        [
+          "set", "{{.Name}}",
+          "--efi-boot", "off"
+        ]
+      ]
     }
   ],
   "provisioners": [


### PR DESCRIPTION
This PR is a rebased and extended version of #155 (thanks, @mewm).
I've verified it with `windows_2012_r2` and made the similar changes for other templates. 

To maintainers: I'm from Parallels team. If you are interested to support the compatibility with `parallels-iso` builder and want to rebuild these boxes periodically, we can provide you with a free license for Parallels Desktop Pro. Just let me know about that.

Closes #155 
