### PR TITLE
Various fixes and allow building on Linux machines with qemu as an alternative to virtualbox/vmware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,6 @@
 .DS_Store
 /iso/*
 !/iso/README.md
-/output-vmware/
-/output-vmware-iso/
-/output-vmware-vmx/
-/output-virtualbox/
-/output-virtualbox-iso/
-/output-virtualbox-ovf/
+/output-*/
 /*.box
 /packer_cache/
-

--- a/answer_files/10/Autounattend.xml
+++ b/answer_files/10/Autounattend.xml
@@ -197,7 +197,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985" </CommandLine>
+                    <CommandLine>cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" profile=any localport=5985 enable=yes action=allow dir=in protocol=tcp</CommandLine>
                     <Description>Win RM port open</Description>
                     <Order>14</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2008_r2/Autounattend.xml
+++ b/answer_files/2008_r2/Autounattend.xml
@@ -173,7 +173,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985" </CommandLine>
+                    <CommandLine>cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" profile=any localport=5985 enable=yes action=allow dir=in protocol=tcp</CommandLine>
                     <Description>Win RM port open</Description>
                     <Order>12</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2008_r2_core/Autounattend.xml
+++ b/answer_files/2008_r2_core/Autounattend.xml
@@ -209,7 +209,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985" </CommandLine>
+                    <CommandLine>cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" profile=any localport=5985 enable=yes action=allow dir=in protocol=tcp</CommandLine>
                     <Description>Win RM port open</Description>
                     <Order>18</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2012/Autounattend.xml
+++ b/answer_files/2012/Autounattend.xml
@@ -178,7 +178,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985" </CommandLine>
+                    <CommandLine>cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" profile=any localport=5985 enable=yes action=allow dir=in protocol=tcp</CommandLine>
                     <Description>Win RM port open</Description>
                     <Order>12</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2012_r2/Autounattend.xml
+++ b/answer_files/2012_r2/Autounattend.xml
@@ -175,7 +175,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985" </CommandLine>
+                    <CommandLine>cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" profile=any localport=5985 enable=yes action=allow dir=in protocol=tcp</CommandLine>
                     <Description>Win RM port open</Description>
                     <Order>12</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2012_r2_core/Autounattend.xml
+++ b/answer_files/2012_r2_core/Autounattend.xml
@@ -175,7 +175,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985" </CommandLine>
+                    <CommandLine>cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" profile=any localport=5985 enable=yes action=allow dir=in protocol=tcp</CommandLine>
                     <Description>Win RM port open</Description>
                     <Order>12</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/2012_r2_hyperv/Autounattend.xml
+++ b/answer_files/2012_r2_hyperv/Autounattend.xml
@@ -175,7 +175,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985" </CommandLine>
+                    <CommandLine>cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" profile=any localport=5985 enable=yes action=allow dir=in protocol=tcp</CommandLine>
                     <Description>Win RM port open</Description>
                     <Order>12</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/7/Autounattend.xml
+++ b/answer_files/7/Autounattend.xml
@@ -174,7 +174,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985" </CommandLine>
+                    <CommandLine>cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" profile=any localport=5985 enable=yes action=allow dir=in protocol=tcp</CommandLine>
                     <Description>Win RM port open</Description>
                     <Order>12</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/answer_files/81/Autounattend.xml
+++ b/answer_files/81/Autounattend.xml
@@ -185,7 +185,7 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985" </CommandLine>
+                    <CommandLine>cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" profile=any localport=5985 enable=yes action=allow dir=in protocol=tcp</CommandLine>
                     <Description>Win RM port open</Description>
                     <Order>12</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/scripts/enable-rdp.bat
+++ b/scripts/enable-rdp.bat
@@ -1,2 +1,3 @@
-netsh advfirewall firewall add rule name="Open Port 3389" dir=in action=allow protocol=TCP localport=3389
+netsh advfirewall firewall add rule name="Open Port 3389" profile=any dir=in action=allow protocol=TCP localport=3389 enable=yes
 reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server" /v fDenyTSConnections /t REG_DWORD /d 0 /f
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v UserAuthentication /t REG_DWORD /d 0 /f

--- a/scripts/rsync.bat
+++ b/scripts/rsync.bat
@@ -5,12 +5,12 @@ if not exist "C:\Windows\Temp\7z920-x64.msi" (
 msiexec /qb /i C:\Windows\Temp\7z920-x64.msi
 
 pushd C:\Windows\Temp
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://mirrors.kernel.org/sourceware/cygwin/x86_64/release/rsync/rsync-3.1.0-1.tar.xz', 'C:\Windows\Temp\rsync-3.1.0-1.tar.xz')" <NUL
-cmd /c ""C:\Program Files\7-Zip\7z.exe" x rsync-3.1.0-1.tar.xz"
-cmd /c ""C:\Program Files\7-Zip\7z.exe" x rsync-3.1.0-1.tar"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://mirrors.kernel.org/sourceware/cygwin/x86_64/release/rsync/rsync-3.1.2-1.tar.xz', 'C:\Windows\Temp\rsync-3.1.2-1.tar.xz')" <NUL
+cmd /c ""C:\Program Files\7-Zip\7z.exe" x rsync-3.1.2-1.tar.xz"
+cmd /c ""C:\Program Files\7-Zip\7z.exe" x rsync-3.1.2-1.tar"
 copy /Y usr\bin\rsync.exe "C:\Program Files\OpenSSH\bin\rsync.exe"
 rmdir /s /q usr
-del rsync-3.1.0-1.tar
+del rsync-3.1.2-1.tar
 popd
 
 msiexec /qb /x C:\Windows\Temp\7z920-x64.msi

--- a/scripts/vm-guest-tools.bat
+++ b/scripts/vm-guest-tools.bat
@@ -1,3 +1,5 @@
+if "%PACKER_BUILDER_TYPE%" equ "qemu" goto :end
+
 if not exist "C:\Windows\Temp\7z920-x64.msi" (
     powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://www.7-zip.org/a/7z920-x64.msi', 'C:\Windows\Temp\7z920-x64.msi')" <NUL
 )
@@ -47,3 +49,5 @@ if exist "C:\Users\vagrant\prl-tools-win.iso" (
 
 :done
 msiexec /qb /x C:\Windows\Temp\7z920-x64.msi
+
+:end

--- a/vagrantfile-windows_10.template
+++ b/vagrantfile-windows_10.template
@@ -18,6 +18,15 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
     config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
 
+    config.vm.provider :libvirt do |v, override|
+        #v.gui = true
+        v.memory = 2048
+        v.cpus = 2
+        v.nic_model_type = "e1000"
+        v.disk_bus = "ide"
+        v.input :type => "tablet", :bus => "usb"
+    end
+
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true
         v.customize ["modifyvm", :id, "--memory", 2048]

--- a/vagrantfile-windows_2008_r2.template
+++ b/vagrantfile-windows_2008_r2.template
@@ -18,6 +18,15 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
     config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
 
+    config.vm.provider :libvirt do |v, override|
+        #v.gui = true
+        v.memory = 2048
+        v.cpus = 2
+        v.nic_model_type = "e1000"
+        v.disk_bus = "ide"
+        v.input :type => "tablet", :bus => "usb"
+    end
+
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true
         v.customize ["modifyvm", :id, "--memory", 2048]

--- a/vagrantfile-windows_2012.template
+++ b/vagrantfile-windows_2012.template
@@ -18,6 +18,15 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
     config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
 
+    config.vm.provider :libvirt do |v, override|
+        #v.gui = true
+        v.memory = 2048
+        v.cpus = 2
+        v.nic_model_type = "e1000"
+        v.disk_bus = "ide"
+        v.input :type => "tablet", :bus => "usb"
+    end
+
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true
         v.customize ["modifyvm", :id, "--memory", 2048]

--- a/vagrantfile-windows_2012_r2.template
+++ b/vagrantfile-windows_2012_r2.template
@@ -18,6 +18,15 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
     config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
 
+    config.vm.provider :libvirt do |v, override|
+        #v.gui = true
+        v.memory = 2048
+        v.cpus = 2
+        v.nic_model_type = "e1000"
+        v.disk_bus = "ide"
+        v.input :type => "tablet", :bus => "usb"
+    end
+
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true
         v.customize ["modifyvm", :id, "--memory", 2048]

--- a/vagrantfile-windows_7.template
+++ b/vagrantfile-windows_7.template
@@ -18,6 +18,15 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
     config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
 
+    config.vm.provider :libvirt do |v, override|
+        #v.gui = true
+        v.memory = 2048
+        v.cpus = 2
+        v.nic_model_type = "e1000"
+        v.disk_bus = "ide"
+        v.input :type => "tablet", :bus => "usb"
+    end
+
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true
         v.customize ["modifyvm", :id, "--memory", 2048]

--- a/vagrantfile-windows_81.template
+++ b/vagrantfile-windows_81.template
@@ -18,6 +18,15 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
     config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
 
+    config.vm.provider :libvirt do |v, override|
+        #v.gui = true
+        v.memory = 2048
+        v.cpus = 2
+        v.nic_model_type = "e1000"
+        v.disk_bus = "ide"
+        v.input :type => "tablet", :bus => "usb"
+    end
+
     config.vm.provider :virtualbox do |v, override|
         #v.gui = true
         v.customize ["modifyvm", :id, "--memory", 2048]

--- a/windows_10.json
+++ b/windows_10.json
@@ -1,6 +1,30 @@
 {
   "builders": [
     {
+      "type": "qemu",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": false,
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "2h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 61440,
+      "vnc_port_min": 5900,
+      "vnc_port_max": 5980,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/fixnetwork.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1"
+      ],
+      "disk_interface": "ide",
+      "net_device": "e1000"
+    },
+    {
       "type": "vmware-iso",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/windows_2008_r2.json
+++ b/windows_2008_r2.json
@@ -1,6 +1,29 @@
 {
   "builders": [
     {
+      "type": "qemu",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": true,
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "2h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 61440,
+      "vnc_port_min": 5900,
+      "vnc_port_max": 5980,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1"
+      ],
+      "disk_interface": "ide",
+      "net_device": "e1000"
+    },
+    {
       "type": "vmware-iso",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/windows_2008_r2_core.json
+++ b/windows_2008_r2_core.json
@@ -1,6 +1,29 @@
 {
   "builders": [
     {
+      "type": "qemu",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": true,
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "2h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 61440,
+      "vnc_port_min": 5900,
+      "vnc_port_max": 5980,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1"
+      ],
+      "disk_interface": "ide",
+      "net_device": "e1000"
+    },
+    {
       "type": "vmware-iso",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/windows_2012.json
+++ b/windows_2012.json
@@ -1,6 +1,29 @@
 {
   "builders": [
     {
+      "type": "qemu",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": true,
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "2h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 61440,
+      "vnc_port_min": 5900,
+      "vnc_port_max": 5980,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1"
+      ],
+      "disk_interface": "ide",
+      "net_device": "e1000"
+    },
+    {
       "type": "vmware-iso",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/windows_2012_r2.json
+++ b/windows_2012_r2.json
@@ -1,6 +1,29 @@
 {
   "builders": [
     {
+      "type": "qemu",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": true,
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "6h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 61440,
+      "vnc_port_min": 5900,
+      "vnc_port_max": 5980,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1"
+      ],
+      "disk_interface": "ide",
+      "net_device": "e1000"
+    },
+    {
       "type": "vmware-iso",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/windows_2012_r2_core.json
+++ b/windows_2012_r2_core.json
@@ -1,6 +1,29 @@
 {
   "builders": [
     {
+      "type": "qemu",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": true,
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "6h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 61440,
+      "vnc_port_min": 5900,
+      "vnc_port_max": 5980,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1"
+      ],
+      "disk_interface": "ide",
+      "net_device": "e1000"
+    },
+    {
       "type": "vmware-iso",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/windows_2012_r2_hyperv.json
+++ b/windows_2012_r2_hyperv.json
@@ -1,6 +1,29 @@
 {
   "builders": [
     {
+      "type": "qemu",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": true,
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "6h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 61440,
+      "vnc_port_min": 5900,
+      "vnc_port_max": 5980,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1"
+      ],
+      "disk_interface": "ide",
+      "net_device": "e1000"
+    },
+    {
       "type": "vmware-iso",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/windows_7.json
+++ b/windows_7.json
@@ -1,6 +1,31 @@
 {
   "builders": [
     {
+      "type": "qemu",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": true,
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "8h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 61440,
+      "vnc_port_min": 5900,
+      "vnc_port_max": 5980,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/dis-updates.ps1",
+        "./scripts/hotfix-KB3102810.bat",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1"
+      ],
+      "disk_interface": "ide",
+      "net_device": "e1000"
+    },
+    {
       "type": "vmware-iso",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/windows_81.json
+++ b/windows_81.json
@@ -1,6 +1,29 @@
 {
   "builders": [
     {
+      "type": "qemu",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": true,
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "2h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 61440,
+      "vnc_port_min": 5900,
+      "vnc_port_max": 5980,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/openssh.ps1"
+      ],
+      "disk_interface": "ide",
+      "net_device": "e1000"
+    },
+    {
       "type": "vmware-iso",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",


### PR DESCRIPTION
1- update rsync version, old one no longer available at mirrors.kernel.org
2- use /image/index in Autounattend.xml so not reliant on precise image name: this is useful when not using identical install media locally (e.g. "Windows 7 Enterprise N" rather than "Windows 7 ENTERPRISE", etc.)
3- use netsh advfirewall command to set up firewall for winrm - this ensures the winrm service is available in all firewall profiles. This is important if vagrant up provides an interface with a different mac address at image runtime compared to packer build time, as happens with vagrant-libvirt
4- allow building on Linux machines with qemu as an alternative to virtualbox/vmware
