### PR TITLE
Fix issue #220: sdelete 2.0 is too slow

### DIFF
--- a/scripts/compact.bat
+++ b/scripts/compact.bat
@@ -12,7 +12,7 @@ if not exist "C:\Windows\Temp\ultradefrag-portable-6.1.0.amd64\udefrag.exe" (
 )
 
 if not exist "C:\Windows\Temp\SDelete.zip" (
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://download.sysinternals.com/files/SDelete.zip', 'C:\Windows\Temp\SDelete.zip')" <NUL
+  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://web.archive.org/web/20140902022253/http://download.sysinternals.com/files/SDelete.zip', 'C:\Windows\Temp\SDelete.zip')" <NUL
 )
 
 if not exist "C:\Windows\Temp\sdelete.exe" (

--- a/scripts/compact.bat
+++ b/scripts/compact.bat
@@ -12,7 +12,7 @@ if not exist "C:\Windows\Temp\ultradefrag-portable-6.1.0.amd64\udefrag.exe" (
 )
 
 if not exist "C:\Windows\Temp\SDelete.zip" (
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://web.archive.org/web/20140902022253/http://download.sysinternals.com/files/SDelete.zip', 'C:\Windows\Temp\SDelete.zip')" <NUL
+  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://web.archive.org/web/20140803110527if_/http://download.sysinternals.com/files/SDelete.zip', 'C:\Windows\Temp\SDelete.zip')" <NUL
 )
 
 if not exist "C:\Windows\Temp\sdelete.exe" (


### PR DESCRIPTION
Back to SDelete 1.61 thanks to archive.org URL

I don't know if some people would prefer to stay with sdelete 2 since it seems sdelete 2 works well for them.