### PR TITLE
Appropriate for Windows 10 x64

### DIFF
--- a/windows_10.json
+++ b/windows_10.json
@@ -42,7 +42,7 @@
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "2h",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "guest_os_type": "Windows81_64",
+      "guest_os_type": "Windows10_64",
       "disk_size": 61440,
       "floppy_files": [
         "{{user `autounattend`}}",


### PR DESCRIPTION
The packer virtualbox builder warns that there are big performance gains to be had for making this be specific. `vboxmanage list ostypes` shows this is the choice for Windows 10 x64.