### PR TITLE
Correctly display Console output after windows update iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* Fixed issue with Console Output (#245)
 
 ## v1.25 (August 13th, 2015)
 

--- a/scripts/win-updates.ps1
+++ b/scripts/win-updates.ps1
@@ -154,8 +154,8 @@ function Install-WindowsUpdates() {
             Title = $UpdatesToInstall.Item($i).Title
             Result = $InstallationResult.GetUpdateResult($i).ResultCode
         }
-        LogWrite "Item: " $UpdatesToInstall.Item($i).Title
-        LogWrite "Result: " $InstallationResult.GetUpdateResult($i).ResultCode;
+        LogWrite "Item: $($UpdatesToInstall.Item($i).Title)"
+        LogWrite "Result: $($InstallationResult.GetUpdateResult($i).ResultCode)"
     }
 
     Check-ContinueRestartOrEnd


### PR DESCRIPTION
Adjust malformed print (LogWrite) statement to successfully display summarized update results in the console.

Closes #245 