### PR TITLE
fix vbox guest tool silent installation on windows due to pending certs

### DIFF
--- a/scripts/vm-guest-tools.bat
+++ b/scripts/vm-guest-tools.bat
@@ -34,6 +34,9 @@ cmd /c certutil -addstore -f "TrustedPublisher" A:\oracle-cert.cer
 
 move /Y C:\Users\vagrant\VBoxGuestAdditions.iso C:\Windows\Temp
 cmd /c ""C:\Program Files\7-Zip\7z.exe" x C:\Windows\Temp\VBoxGuestAdditions.iso -oC:\Windows\Temp\virtualbox"
+certutil -addstore -f "TrustedPublisher" C:\Windows\Temp\virtualbox\cert\vbox-sha256-r3.cer
+certutil -addstore -f "TrustedPublisher" C:\Windows\Temp\virtualbox\cert\vbox-sha256.cer
+certutil -addstore -f "TrustedPublisher" C:\Windows\Temp\virtualbox\cert\vbox-sha1.cer
 cmd /c C:\Windows\Temp\virtualbox\VBoxWindowsAdditions.exe /S
 goto :done
 


### PR DESCRIPTION
I had issues deploying the VBoxGuest tools with VBox 5.1.22 and this fixed the issue.