### PR TITLE
Use HTTPS to reduce man-in-the-middle attack vector

### DIFF
--- a/scripts/openssh.ps1
+++ b/scripts/openssh.ps1
@@ -6,7 +6,7 @@ Write-Output "AutoStart: $AutoStart"
 $is_64bit = [IntPtr]::size -eq 8
 
 # setup openssh
-$ssh_download_url = "http://www.mls-software.com/files/setupssh-7.1p1-1.exe"
+$ssh_download_url = "https://www.mls-software.com/files/setupssh-7.1p1-1.exe"
 
 if (!(Test-Path "C:\Program Files\OpenSSH\bin\ssh.exe")) {
     Write-Output "Downloading $ssh_download_url"


### PR DESCRIPTION
The URL also works as "https://www.mls-software.com/files/setupssh-7.1p1-1.exe" so this would reduce potential for man-in-the-middle attacks compromising the build.