### PR TITLE
Fix Windows 10 box name

### DIFF
--- a/vagrantfile-windows_10.template
+++ b/vagrantfile-windows_10.template
@@ -4,8 +4,8 @@
 Vagrant.require_version ">= 1.6.2"
 
 Vagrant.configure("2") do |config|
-    config.vm.define "vagrant-windows-10-preview"
-    config.vm.box = "windows_10_preview"
+    config.vm.define "vagrant-windows-10"
+    config.vm.box = "windows_10"
     config.vm.communicator = "winrm"
 
     # Admin user name and password


### PR DESCRIPTION
Since commit c2a80b2efc the final instead of the technical preview iso is used.